### PR TITLE
Specify aiohttp version to avoid import errors

### DIFF
--- a/01-tutorials/01-fundamentals/02-model-providers/02-openai-model/requirements.txt
+++ b/01-tutorials/01-fundamentals/02-model-providers/02-openai-model/requirements.txt
@@ -1,3 +1,4 @@
 strands-agents
 strands-agents-tools
 strands-agents[litellm]
+aiohttp>=3.12.13


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Older versions of aiohttp will raise error during litellm import in this notebook

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
