### PR TITLE
docs: Update README.md to raises Model Access with CRI for Streamlit template

### DIFF
--- a/04-UX-demos/01-streamlit-template/README.md
+++ b/04-UX-demos/01-streamlit-template/README.md
@@ -40,7 +40,7 @@ Prerequisites:
 * python >= 3.8 (tested on 3.11)
 * docker
 * use a Chrome browser for development
-* `anthropic.claude-3-7-sonnet` model activated in Amazon Bedrock in your AWS account. [Instructions](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
+* `anthropic.claude-3-7-sonnet` model activated in Amazon Bedrock in your AWS account, in **each** AWS region of the Cross Region Inference profile. [Instructions](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html).
 * This demo has been tested on a mac laptop with colima as container runtime, but it should also work with other configurations.
 * You also need to install the AWS Command Line Interface (CLI), the AWS Cloud Development KIT (CDK), and to configure the AWS CLI on your development environment. One way to configure the AWS CLI is to get your access key through the AWS console, and use the `aws configure` command in your terminal to setup your credentials.
 


### PR DESCRIPTION
*Issue* #70 

*Description of changes:*

Raise Model Access request in the introductive README of `04-UX-demos/01-streamlit-template` for the Cross Region Inference profile. I encountered validation errors due to the fact that I enabled it only in 1 of the 3 regions of the CRI profile first, and it wasn't clearly pointed out in the documentation.

Theses few lines might help anybody to fasten the setup to test this great showcase 👍 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. ✅ 

