### PR TITLE
remove reference to max_parallel_tools

### DIFF
--- a/01-tutorials/01-fundamentals/04-tools/01-using-mcp-tools/mcp-agent.ipynb
+++ b/01-tutorials/01-fundamentals/04-tools/01-using-mcp-tools/mcp-agent.ipynb
@@ -347,7 +347,7 @@
    "source": [
     "### Interacting with multiple MCP servers\n",
     "\n",
-    "With Strands Agents you can also interact with multiple MCP servers using the same agent and configure tools setups such as the max number of tools that can be used in parallel (`max_parallel_tools`). Let's create a new agent to show case this configuration:\n",
+    "With Strands Agents you can also interact with multiple MCP servers using the same agent and configure tools setups. Let's create a new agent to show case this configuration:\n",
     "\n",
     "<div style=\"text-align:center\">\n",
     "    <img src=\"images/architecture_3.png\" width=\"85%\" />\n",
@@ -402,7 +402,7 @@
     "    tools = aws_docs_mcp_client.list_tools_sync() + cdk_mcp_client.list_tools_sync()\n",
     "\n",
     "    # Create an agent with these tools\n",
-    "    agent = Agent(tools=tools, max_parallel_tools=2)\n",
+    "    agent = Agent(tools=tools)\n",
     "\n",
     "    response = agent(\n",
     "        \"What is Amazon Bedrock pricing model. Be concise. Also what are the best practices related to CDK?\"\n",


### PR DESCRIPTION
## Description
`max_parallel_tools` is no longer a parameter of `Agent.__init__`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
