### PR TITLE
Observabillity updates

### DIFF
--- a/01-tutorials/01-fundamentals/08-observability-and-evaluation/Observability-and-Evaluation-sample.ipynb
+++ b/01-tutorials/01-fundamentals/08-observability-and-evaluation/Observability-and-Evaluation-sample.ipynb
@@ -86,6 +86,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Now let's make sure we are running the latest version of Strands Agents Tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install strands-agents-tools>=0.2.3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Deploy Amazon Bedrock Knowledge Base and DynamoDB table"
    ]
   },

--- a/01-tutorials/01-fundamentals/08-observability-and-evaluation/requirements.txt
+++ b/01-tutorials/01-fundamentals/08-observability-and-evaluation/requirements.txt
@@ -6,7 +6,6 @@ requests-aws4auth
 pyyaml
 retrying
 strands-agents
-strands-agents-tools>=0.2.3
 langfuse
 ragas
 langchain-aws


### PR DESCRIPTION
Strands agent tools package update need to be seprated form requirement.txt due to conflicting dependencies between this package,dill and datasets version 4.0.
