### PR TITLE
updated mcp-agent.ipynb

### DIFF
--- a/01-tutorials/01-fundamentals/04-tools/01-using-mcp-tools/mcp-agent.ipynb
+++ b/01-tutorials/01-fundamentals/04-tools/01-using-mcp-tools/mcp-agent.ipynb
@@ -158,6 +158,7 @@
    "outputs": [],
    "source": [
     "# Create an agent with MCP tools\n",
+    "#Get NotImplementedError on WIndows OS for Python313\\site-packages\\mcp\\os\\win32\\utilities.py:169, in create_windows_process(command, args, env, errlog, cwd)\n",
     "with stdio_mcp_client:\n",
     "    # Get the tools from the MCP server\n",
     "    tools = stdio_mcp_client.list_tools_sync()\n",

--- a/01-tutorials/01-fundamentals/08-observability-and-evaluation/Observability-and-Evaluation-sample.ipynb
+++ b/01-tutorials/01-fundamentals/08-observability-and-evaluation/Observability-and-Evaluation-sample.ipynb
@@ -86,6 +86,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Now let's make sure we are running the latest version of Strands Agents Tools"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install strands-agents-tools>=0.2.3"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Deploy Amazon Bedrock Knowledge Base and DynamoDB table"
    ]
   },
@@ -196,6 +212,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#Get the error ModuleNotFoundError: No module named 'strands_tools'\n",
     "import get_booking_details, delete_booking, create_booking\n",
     "from strands_tools import retrieve, current_time\n",
     "from strands import Agent, tool\n",


### PR DESCRIPTION
*Issue #, if available: 

When executing the code below in Kiro and Visual Studio code on WIndows OS

# Create an agent with MCP tools
with stdio_mcp_client:
    # Get the tools from the MCP server
    tools = stdio_mcp_client.list_tools_sync()

    # Create an agent with these tools
    agent = Agent(
        model="us.anthropic.claude-3-7-sonnet-20250219-v1:0",
        tools=tools)

    response = agent("What is Amazon Bedrock pricing model. Be concise.")


Get the following error:

---------------------------------------------------------------------------
NotImplementedError                       Traceback (most recent call last)
File ~\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\LocalCache\local-packages\Python313\site-packages\mcp\os\win32\utilities.py:169, in create_windows_process(command, args, env, errlog, cwd)
    167 try:
    168     # First try using anyio with Windows-specific flags to hide console window
--> 169     process = await anyio.open_process(
    170         [command, *args],
    171         env=env,
    172         # Ensure we don't create console windows for each process
    173         creationflags=subprocess.CREATE_NO_WINDOW  # type: ignore
    174         if hasattr(subprocess, "CREATE_NO_WINDOW")
    175         else 0,
    176         stderr=errlog,
    177         cwd=cwd,
    178     )
    179 except NotImplementedError:
    180     # If Windows doesn't support async subprocess creation, use fallback

File ~\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.13_qbz5n2kfra8p0\LocalCache\local-packages\Python313\site-packages\anyio\_core\_subprocesses.py:190, in open_process(command, stdin, stdout, stderr, cwd, env, startupinfo, creationflags, start_new_session, pass_fds, user, group, extra_groups, umask)
    188     kwargs["umask"] = umask
--> 190 return await get_async_backend().open_process(
    191     command,
    192     stdin=stdin,
    193     stdout=stdout,
    194     stderr=stderr,
...
    117     logger.exception("client failed to initialize")
--> 118     raise MCPClientInitializationError("the client initialization failed") from e
    119 return self

MCPClientInitializationError: the client initialization failed

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
