### PR TITLE
Add Region to SSM Client Initialization to prevent permissions exception

### DIFF
--- a/01-tutorials/01-fundamentals/03-connecting-with-aws-services/prereqs/dynamodb.py
+++ b/01-tutorials/01-fundamentals/03-connecting-with-aws-services/prereqs/dynamodb.py
@@ -29,7 +29,7 @@ class AmazonDynamoDB:
         self._region = self._boto_session.region_name
         self._dynamodb_client = boto3.client("dynamodb", region_name=self._region)
         self._dynamodb_resource = boto3.resource("dynamodb", region_name=self._region)
-        self._smm_client = boto3.client("ssm")
+        self._smm_client = boto3.client("ssm", region_name=self._region)
         print(self._dynamodb_client, self._dynamodb_resource)
 
     def create_dynamodb(


### PR DESCRIPTION
*Title:* Add Region to SSM Client Initialization to prevent permissions exception

*Description of changes:*
Even with elevated permissions, the shell script can fail to deploy SSM parameters if the region isn't defined and if the user is operating outside of `us-east-1`.

This change adds `region_name=self._region` to the ssm client initialization which resolves the issue, as long as the user has updated the bedrock execution role with necessary SSM permissions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
