### PR TITLE
docs: add instruction about linking issues in PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,9 @@ To send us a pull request, please:
 3. Ensure local tests pass.
 4. Commit to your fork using clear commit messages.
 5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+6. When opening a PR that fixes an issue, please include `Fixes #<issue-number>` in the PR description so GitHub automatically closes the issue on merge.
+7. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
 [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added instruction in CONTRIBUTING.md to include 'Fixes #<issue-number>' in PR  descriptions for automatic issue closing on merge.