### PR TITLE
fix: remove non-existent [a2a] extra from strands-agents-tools depend…

### DIFF
--- a/03-integrations/Native-A2A-Support/pyproject.toml
+++ b/03-integrations/Native-A2A-Support/pyproject.toml
@@ -6,6 +6,6 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "strands-agents[a2a]>=1.3.0",
-    "strands-agents-tools[a2a]>=0.2.0",
+    "strands-agents-tools>=0.2.0",
     "a2a-sdk[sql]>=0.3.0",
 ]


### PR DESCRIPTION
…ency

The strands-agents-tools package version 0.2.8 does not have an 'a2a' extra, causing installation warnings. Only strands-agents has the [a2a] extra.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
