### PR TITLE
Fix Ollama tutorial: add PDF support and correct model config

### DIFF
--- a/01-tutorials/01-fundamentals/02-model-providers/01-ollama-model/ollama_file_ops_agent.ipynb
+++ b/01-tutorials/01-fundamentals/02-model-providers/01-ollama-model/ollama_file_ops_agent.ipynb
@@ -97,7 +97,7 @@
    },
    "outputs": [],
    "source": [
-    "!ollama pull llama3.2:1b"
+    "!ollama pull llama3.2:3b"
    ]
   },
   {
@@ -148,11 +148,9 @@
    "outputs": [],
    "source": [
     "# File Operation Tools\n",
-    "\n",
-    "\n",
     "@tool\n",
     "def file_read(file_path: str) -> str:\n",
-    "    \"\"\"Read a file and return its content.\n",
+    "    \"\"\"Read a file and return its content. Supports both text and PDF files.\n",
     "\n",
     "    Args:\n",
     "        file_path (str): Path to the file to read\n",
@@ -164,8 +162,19 @@
     "        FileNotFoundError: If the file doesn't exist\n",
     "    \"\"\"\n",
     "    try:\n",
-    "        with open(file_path, \"r\") as file:\n",
-    "            return file.read()\n",
+    "        # Check if it's a PDF file\n",
+    "        if file_path.lower().endswith('.pdf'):\n",
+    "            import PyPDF2\n",
+    "            with open(file_path, \"rb\") as file:\n",
+    "                pdf_reader = PyPDF2.PdfReader(file)\n",
+    "                text = \"\"\n",
+    "                for page in pdf_reader.pages:\n",
+    "                    text += page.extract_text() + \"\\n\"\n",
+    "                return text if text.strip() else \"Error: Could not extract text from PDF\"\n",
+    "        else:\n",
+    "            # Regular text file\n",
+    "            with open(file_path, \"r\", encoding=\"utf-8\") as file:\n",
+    "                return file.read()\n",
     "    except FileNotFoundError:\n",
     "        return f\"Error: File '{file_path}' not found.\"\n",
     "    except Exception as e:\n",
@@ -268,7 +277,7 @@
     "\"\"\"\n",
     "\n",
     "model_id = (\n",
-    "    \"llama3.2:1b\"  # You can change this to any model you have pulled with Ollama.\n",
+    "    \"llama3.2:3b\"  # You can change this to any model you have pulled with Ollama.\n",
     ")"
    ]
   },
@@ -289,12 +298,9 @@
     "ollama_model = OllamaModel(\n",
     "    model_id=model_id,\n",
     "    host=\"http://localhost:11434\",\n",
-    "    params={\n",
-    "        \"max_tokens\": 4096,  # Adjust based on your model's capabilities\n",
-    "        \"temperature\": 0.7,  # Lower for more deterministic responses, higher for more creative\n",
-    "        \"top_p\": 0.9,  # Nucleus sampling parameter\n",
-    "        \"stream\": True,  # Enable streaming responses\n",
-    "    },\n",
+    "    max_tokens=4096,  # Adjust based on your model's capabilities\n",
+    "    temperature=0.7,  # Lower for more deterministic responses, higher for more creative\n",
+    "    top_p=0.9,  # Nucleus sampling parameter\n",
     ")\n",
     "\n",
     "# Create the agent\n",
@@ -378,7 +384,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "genai-on-aws",
    "language": "python",
    "name": "python3"
   },
@@ -392,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/01-tutorials/01-fundamentals/02-model-providers/01-ollama-model/requirements.txt
+++ b/01-tutorials/01-fundamentals/02-model-providers/01-ollama-model/requirements.txt
@@ -1,3 +1,4 @@
 strands-agents
 strands-agents-tools
 strands-agents[ollama]
+PyPDF2>=3.0.0


### PR DESCRIPTION
### Summary
 This PR fixes two issues in the Ollama tutorial that prevented PDF file reading from working correctly.

### Description of changes
1. **Upgraded model** - Changed from `llama3.2:1b` to `llama3.2:3b` for better tool calling reliability
2. **Fixed OllamaModel configuration** - Removed invalid `params` wrapper and used direct parameters (`max_tokens`, `temperature`, `top_p`) 
3. **Added PDF reading support** - Updated `file_read` tool to detect and extract text from PDF files using PyPDF2
4. **Updated dependencies** - Added PyPDF2>=3.0.0 to requirements.txt



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
