### PR TITLE
Fix missing packages in AgentCore deployment tutorial

### DIFF
--- a/01-tutorials/03-deployment/03-agentcore-deployment/agent-requirements.txt
+++ b/01-tutorials/03-deployment/03-agentcore-deployment/agent-requirements.txt
@@ -1,5 +1,0 @@
-boto3>=1.40.0
-strands-agents>=0.1.0
-strands-agents-tools>=0.1.0
-awscli
-botocore

--- a/01-tutorials/03-deployment/03-agentcore-deployment/deploy-agent.ipynb
+++ b/01-tutorials/03-deployment/03-agentcore-deployment/deploy-agent.ipynb
@@ -61,7 +61,9 @@
     "  bedrock-agentcore-starter-toolkit \\\n",
     "  bedrock-agentcore \\\n",
     "  strands-agents \\\n",
-    "  strands-agents-tools"
+    "  strands-agents-tools \\\n",
+    "  opensearch-py \\\n",
+    "  retrying"
    ]
   },
   {
@@ -1249,7 +1251,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "genai-on-aws",
    "language": "python",
    "name": "python3"
   },
@@ -1263,7 +1265,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Description of changes:*
   - Add opensearch-py and retrying to the pip install cell in the AgentCore deployment notebook
  - Remove unused agent-requirements.txt file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
