### PR TITLE
Fix ticker extraction, swarm timeouts, and region warnings in finance assistant

### DIFF
--- a/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/README.md
+++ b/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/README.md
@@ -4,7 +4,7 @@ Author: Julia Hu
 
 Finance-Assistant Swarm Agent Collaboration is a modular, multi-agent system designed to autonomously generate comprehensive equity research reports from a single stock query. Built using the Strands SDK and powered by Amazon Bedrock, this assistant orchestrates a collaborative swarm of specialized agents—each responsible for a distinct financial research task including ticker resolution, company profiling, price analytics, financial health assessment, and sentiment analysis.
 
-By leveraging shared memory and coordinated agent workflows, the system transforms raw data from APIs and web sources into a polished, structured Markdown or HTML report. The orchestrator uses natural language reasoning and synthesis (via Amazon Nova) to integrate the findings into actionable insights. The architecture supports flexible deployment, modular agent execution, and scalable financial intelligence delivery for developers, analysts, and automated trading systems.
+By leveraging shared memory and coordinated agent workflows, the system transforms raw data from APIs and web sources into a polished, structured Markdown or HTML report. The orchestrator uses natural language reasoning and synthesis (via Claude Opus 4.6 on Amazon Bedrock) to integrate the findings into actionable insights. The architecture supports flexible deployment, modular agent execution, and scalable financial intelligence delivery for developers, analysts, and automated trading systems.
 
 ![Architecture](images/architecture_stock_swarm.png)
 
@@ -27,7 +27,7 @@ A modular swarm of agents that delivers a **holistic equity research report** fr
 2. Orchestrator calls `ticker_search_agent` → resolves correct ticker
 3. Ticker is **broadcast** to specialised agents (shared memory)
 4. Each agent pulls data, analyses, writes a _section draft_
-5. Orchestrator **integrates & polishes** into one cohesive report using Amazon Nova
+5. Orchestrator **integrates & polishes** into one cohesive report using Claude Opus 4.6
 6. Final Markdown / HTML returned to the user (CLI, API, or chat UI)
 
 ## 3. Report format 📋
@@ -46,7 +46,7 @@ The orchestrator outputs five ordered sections:
 
 - Python 3.10+
 - AWS CLI v2 configured
-- [Access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to Amazon Bedrock (Nova in us-east-1 region)
+- [Access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) to Amazon Bedrock (Claude Opus 4.6 via cross-region inference)
 
 ### Running the Application
 
@@ -76,7 +76,7 @@ uv run company_analysis_agent.py
 | Data Pipeline | Bedrock Data Automation | Converts raw Audio files → embeddable docs |
 | Storage Layer | S3 | Durable store for documents & images |
 | Search Layer | Amazon Bedrock Knowledge Base | Vector / keyword index for RAG_agent |
-| AI Services | Amazon Nova | Foundation model for text + image generation |
+| AI Services | Claude Opus 4.6 (Amazon Bedrock) | Foundation model for analysis and synthesis |
 
 ## 6. Troubleshooting 🐞
 

--- a/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/company_analysis_agent.py
+++ b/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/company_analysis_agent.py
@@ -432,7 +432,7 @@ When user provides a company ticker:
    - Potential Risks
    - Overall Assessment
 </output_format>""",
-        model=BedrockModel(model_id="us.amazon.nova-pro-v1:0", region="us-east-1"),
+        model=BedrockModel(model_id="us.anthropic.claude-opus-4-6-v1"),
         tools=[get_company_info, get_stock_news, http_request, think],
     )
 

--- a/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/finance_assistant_swarm.py
+++ b/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/finance_assistant_swarm.py
@@ -81,8 +81,8 @@ def _extract_ticker(query: str) -> str:
     return stripped[:5] if stripped else "UNKNOWN"
 
 
-# Model used for the swarm agents — use a fast model to avoid timeouts.
-# Switch to "us.anthropic.claude-opus-4-6-v1" for higher quality (requires longer timeouts).
+# Model used for the swarm agents — using Opus for highest quality.
+# Switch to a faster model like Haiku or Sonnet if you hit timeouts.
 SWARM_MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
 
 # Model used for the orchestration agent (deep synthesis).

--- a/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/finance_assistant_swarm.py
+++ b/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/finance_assistant_swarm.py
@@ -6,6 +6,7 @@ A collaborative swarm of specialized agents for comprehensive stock analysis.
 """
 # Standard library imports
 import logging
+import re
 import time
 from typing import Dict, Any, List
 
@@ -62,40 +63,66 @@ def get_real_stock_data(ticker: str) -> Dict[str, Any]:
     except Exception as e:
         return {"status": "error", "message": str(e)}
 
+def _extract_ticker(query: str) -> str:
+    """Extract a stock ticker symbol from a query string.
+
+    Handles cases like 'ALK', 'Analyze ALK', 'ALK (Alaska Air Group)', etc.
+    """
+    # If the query itself is already a short ticker, use it directly
+    stripped = query.strip().upper()
+    if re.fullmatch(r"[A-Z]{1,5}", stripped):
+        return stripped
+
+    # Try to find a 1-5 letter uppercase word that looks like a ticker
+    match = re.search(r"\b([A-Z]{1,5})\b", query.upper())
+    if match:
+        return match.group(1)
+
+    return stripped[:5] if stripped else "UNKNOWN"
+
+
+# Model used for the swarm agents — use a fast model to avoid timeouts.
+# Switch to "us.anthropic.claude-opus-4-6-v1" for higher quality (requires longer timeouts).
+SWARM_MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
+
+# Model used for the orchestration agent (deep synthesis).
+ORCHESTRATOR_MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
+
+
 @tool
-def analyze_company_with_collaborative_swarm(query: str, stock_data: str = "") -> Dict[str, Any]:
-    """Collaborative swarm using Nova LITE to avoid streaming timeouts"""
+def analyze_company_with_collaborative_swarm(ticker: str) -> Dict[str, Any]:
+    """Run a collaborative swarm analysis for a stock ticker symbol (e.g. 'ALK', 'AAPL', 'MSFT').
+    The ticker parameter must be a valid stock ticker symbol, not a full sentence."""
     try:
-        ticker = query.upper() if len(query) <= 5 else "AMZN"
-        
-        # Use NOVA LITE for all swarm agents - much faster, no timeouts
+        ticker = _extract_ticker(ticker)
+
         company_strategist = Agent(
             name="company_strategist",
-            system_prompt=f"Analyze {ticker} business model. Use get_company_info then hand off to financial_analyst.",
-            model=BedrockModel(model_id="us.amazon.nova-lite-v1:0", region="us-east-1"),
+            system_prompt=f"Analyze {ticker} business model. Use get_company_info with ticker '{ticker}', then hand off to financial_analyst.",
+            model=BedrockModel(model_id=SWARM_MODEL_ID),
             tools=[get_company_info]
         )
-        
+
         financial_analyst = Agent(
-            name="financial_analyst", 
-            system_prompt=f"Build on company insights. Use get_financial_metrics then hand off to market_analyst.",
-            model=BedrockModel(model_id="us.amazon.nova-lite-v1:0", region="us-east-1"),
+            name="financial_analyst",
+            system_prompt=f"Build on the company insights for {ticker}. Use get_financial_metrics with ticker '{ticker}', then hand off to market_analyst.",
+            model=BedrockModel(model_id=SWARM_MODEL_ID),
             tools=[get_financial_metrics]
         )
-        
+
         market_analyst = Agent(
             name="market_analyst",
-            system_prompt=f"Synthesize all insights. Use get_stock_news for final recommendation.",
-            model=BedrockModel(model_id="us.amazon.nova-lite-v1:0", region="us-east-1"),
+            system_prompt=f"Synthesize all insights for {ticker}. Use get_stock_news with ticker '{ticker}' for final recommendation.",
+            model=BedrockModel(model_id=SWARM_MODEL_ID),
             tools=[get_stock_news]
         )
-        
+
         swarm = Swarm(
             [company_strategist, financial_analyst, market_analyst],
             max_handoffs=3,
             max_iterations=3,
-            execution_timeout=120.0,
-            node_timeout=30.0
+            execution_timeout=300.0,
+            node_timeout=90.0
         )
         
         result = swarm(f"Analyze {ticker}")
@@ -109,28 +136,29 @@ def analyze_company_with_collaborative_swarm(query: str, stock_data: str = "") -
         return {"status": "error", "collaborative_analysis": f"Analysis failed: {str(e)}"}
 
 def create_orchestration_agent() -> Agent:
-    """Orchestrator with Nova Pro for deep synthesis"""
+    """Orchestrator for deep synthesis"""
     return Agent(
-        system_prompt="""You are a senior research director using Nova Pro.
+        system_prompt="""You are a senior research director.
 
         WORKFLOW:
-        1. Get real stock data using get_real_stock_data  
-        2. Get ONE collaborative analysis using analyze_company_with_collaborative_swarm
+        1. Get real stock data using get_real_stock_data with the ticker symbol
+        2. Get ONE collaborative analysis using analyze_company_with_collaborative_swarm — pass ONLY the ticker symbol (e.g. "ALK"), NOT a full sentence
         3. Synthesize using think tool for deep strategic insights
-        
+
         CRITICAL RULES:
+        - When calling analyze_company_with_collaborative_swarm, pass ONLY the stock ticker symbol (e.g. "ALK", "AAPL"), never a full sentence
         - DO NOT call analyze_company_with_collaborative_swarm multiple times
         - Focus on synthesis and strategic conclusions
         - Always prominently display the current stock price
         - Provide deep insights that demonstrate collaborative agent value
-        
+
         REPORT STRUCTURE:
         1. Executive Summary (current price + key thesis)
         2. Strategic Business Analysis (from collaborative insights)
         3. Financial Health Assessment (integrated metrics)
         4. Market Sentiment Analysis (news + trends)
         5. Investment Recommendation (buy/hold/sell with rationale)""",
-        model=BedrockModel(model_id="us.amazon.nova-pro-v1:0", region="us-east-1"),
+        model=BedrockModel(model_id=ORCHESTRATOR_MODEL_ID),
         tools=[get_real_stock_data, analyze_company_with_collaborative_swarm, think],
     )
 
@@ -159,7 +187,7 @@ def main():
     # Initialize messages for the orchestration agent
     orchestration_agent.messages = create_initial_messages()
 
-    print("\n🤖 Hybrid Multi-Agent Stock Analysis (Nova Lite Swarm + Nova Pro Synthesis) 📊")
+    print("\n🤖 Hybrid Multi-Agent Stock Analysis 📊")
     print("Features: Real-time data + Fast collaborative swarm + Deep orchestrator synthesis\n")
 
     while True:

--- a/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/financial_metrics_agent.py
+++ b/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/financial_metrics_agent.py
@@ -128,7 +128,7 @@ When user provides a company ticker:
    - Return on Equity
    - Risk Assessment
 </output_format>""",
-        model=BedrockModel(model_id="us.amazon.nova-pro-v1:0", region="us-east-1"),
+        model=BedrockModel(model_id="us.anthropic.claude-opus-4-6-v1"),
         tools=[get_financial_metrics, http_request, think],
     )
 

--- a/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/stock_price_agent.py
+++ b/python/04-industry-use-cases/finance/finance-assistant-swarm-agent/stock_price_agent.py
@@ -97,7 +97,7 @@ When user provides a company name or ticker:
 
 3. Key Metrics Summary
 </output_format>""",
-        model=BedrockModel(model_id="us.amazon.nova-pro-v1:0", region="us-east-1"),
+        model=BedrockModel(model_id="us.anthropic.claude-opus-4-6-v1"),
         tools=[get_stock_prices, http_request, think],
     )
 


### PR DESCRIPTION
## Summary
- Fix ticker defaulting to AMZN when orchestrator passes full sentences by adding `_extract_ticker()` helper
- Include ticker in all swarm agent system prompts so each agent knows which company to analyze
- Increase node_timeout (30s → 90s) and execution_timeout (120s → 300s) to prevent timeout errors
- Remove deprecated `region` parameter from BedrockModel calls
- Update model to Opus 4.6 via configurable constants
- Update orchestrator prompt to instruct passing ticker symbols only

## Test plan
- [x] Run `uv run finance_assistant_swarm.py` with ticker `ALK`
- [x] Verify 0 occurrences of AMZN in output
- [x] Verify 0 `Invalid configuration parameters: ['region']` warnings
- [x] Verify 0 timeout errors — all swarm runs complete with `Status.COMPLETED`