### PR TITLE
Add 16-hooks-lifecycle tutorial for the Strands hooks system

### DIFF
--- a/python/01-learn/16-hooks-lifecycle/01_hooks_basics.ipynb
+++ b/python/01-learn/16-hooks-lifecycle/01_hooks_basics.ipynb
@@ -1,0 +1,322 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0e028468",
+   "metadata": {},
+   "source": [
+    "# Hooks Basics: Your First Hook and the Event Lifecycle\n",
+    "\n",
+    "Hooks let you observe, extend, and control a Strands agent at runtime. Every agent invocation fires a sequence of typed events (`BeforeInvocationEvent`, `BeforeModelCallEvent`, `BeforeToolCallEvent`, and their `After*` counterparts), and each event gives a hook a chance to read agent state, modify specific writable fields, or short-circuit execution.\n",
+    "\n",
+    "This notebook covers two foundational topics:\n",
+    "\n",
+    "1. **Your first hook** - register a callback and measure model latency.\n",
+    "2. **The full event lifecycle** - print the exact order of every event across model and tool calls.\n",
+    "\n",
+    "Every example is self-contained and runnable.\n",
+    "\n",
+    "> **Next:** [02_hooks_intercept.ipynb](./02_hooks_intercept.ipynb) covers writable fields that let hooks block tools, retry calls, and auto-continue the agent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e69d41f4",
+   "metadata": {},
+   "source": [
+    "## Lifecycle at a glance\n",
+    "\n",
+    "```\n",
+    "agent(\"Summarize the weather in Seattle\")\n",
+    "|\n",
+    "+-- BeforeInvocationEvent              <-- once per request\n",
+    "|   +-- MessageAddedEvent  (user message appended)\n",
+    "|\n",
+    "+-- BeforeModelCallEvent               <-- each model invocation\n",
+    "|   +-- AfterModelCallEvent            <-- writable: retry\n",
+    "|      +-- MessageAddedEvent (assistant turn)\n",
+    "|\n",
+    "+-- BeforeToolCallEvent                <-- each requested tool\n",
+    "|   |                                      writable: cancel_tool, selected_tool, tool_use\n",
+    "|   +-- AfterToolCallEvent             <-- writable: result, retry   (reverse order)\n",
+    "|      +-- MessageAddedEvent (tool result)\n",
+    "|\n",
+    "+-- (model -> tools loop until end_turn)\n",
+    "|\n",
+    "+-- AfterInvocationEvent               <-- once per request (reverse order)\n",
+    "                                           writable: resume\n",
+    "```\n",
+    "\n",
+    "`After*` callbacks fire in **reverse** registration order (the same inversion pattern as `try/finally`), so an outer observer sees what an inner one changed.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a38c3367",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "This tutorial uses Claude Haiku 4.5 on Amazon Bedrock by default. It works with any Strands-supported model. Swap the `model=` argument in the `Agent(...)` constructor if you prefer a different provider (see [Model Providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/)).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54dfbb09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -r requirements.txt --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "469e7218",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import time\n",
+    "\n",
+    "from strands import Agent, tool\n",
+    "from strands.hooks import (\n",
+    "    AgentInitializedEvent,\n",
+    "    BeforeInvocationEvent,\n",
+    "    AfterInvocationEvent,\n",
+    "    BeforeModelCallEvent,\n",
+    "    AfterModelCallEvent,\n",
+    "    BeforeToolCallEvent,\n",
+    "    AfterToolCallEvent,\n",
+    "    MessageAddedEvent,\n",
+    "    HookProvider,\n",
+    "    HookRegistry,\n",
+    ")\n",
+    "\n",
+    "# Use the same Bedrock inference profile as the other 01-learn tutorials.\n",
+    "MODEL_ID = \"us.anthropic.claude-haiku-4-5-20251001-v1:0\"\n",
+    "\n",
+    "# Quiet SDK logs so the hook demonstrations stay the focus of the output.\n",
+    "logging.getLogger(\"strands\").setLevel(logging.WARNING)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "defcb8d9",
+   "metadata": {},
+   "source": [
+    "## 1. Your first hook: `BeforeModelCallEvent` and `AfterModelCallEvent`\n",
+    "\n",
+    "The simplest hook is a plain function that takes an event argument. Register it with `agent.add_hook(callback)`. Strands infers the event type from your type hint.\n",
+    "\n",
+    "Below we register a pair of hooks that time every model call.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70029a72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_timings: list[float] = []\n",
+    "\n",
+    "def start_timer(event: BeforeModelCallEvent) -> None:\n",
+    "    # Stash the start time on the event's invocation_state so the matching\n",
+    "    # After* hook can read it. invocation_state is a per-request dict.\n",
+    "    event.invocation_state[\"_model_start\"] = time.perf_counter()\n",
+    "\n",
+    "def record_duration(event: AfterModelCallEvent) -> None:\n",
+    "    start = event.invocation_state.get(\"_model_start\")\n",
+    "    if start is not None:\n",
+    "        model_timings.append(time.perf_counter() - start)\n",
+    "\n",
+    "agent = Agent(model=MODEL_ID, callback_handler=None)\n",
+    "agent.add_hook(start_timer)\n",
+    "agent.add_hook(record_duration)\n",
+    "\n",
+    "result = agent(\"In one sentence, what is a hook?\")\n",
+    "print(\"model calls:\", len(model_timings))\n",
+    "print(\"avg latency:\", f\"{sum(model_timings) / len(model_timings):.2f}s\")\n",
+    "print(\"answer:\", str(result).strip())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c64658f3",
+   "metadata": {},
+   "source": [
+    "Two things worth noticing:\n",
+    "\n",
+    "* `agent.add_hook(callback)` uses the callback's type annotation (`event: BeforeModelCallEvent`) to bind the event type. You can also pass the type explicitly: `agent.add_hook(start_timer, BeforeModelCallEvent)`.\n",
+    "* We shared data between the two hooks through `event.invocation_state`, a dictionary that lives for the duration of one `agent(...)` call. We will return to this pattern in [03_hooks_packaging.ipynb](./03_hooks_packaging.ipynb).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b7ce188",
+   "metadata": {},
+   "source": [
+    "Two other things worth knowing about registration:\n",
+    "\n",
+    "* **`AgentInitializedEvent`** fires once at the end of the `Agent(...)` constructor. It is the right place for one-time setup that needs a fully constructed agent.\n",
+    "* `HookProvider` instances can be attached either via the constructor (`Agent(hooks=[MyProvider()])`) or **after construction** with `agent.hooks.add_hook(MyProvider())`. The next cell shows both.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c543a27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class StartupLogger(HookProvider):\n",
+    "    \"\"\"Run once when the agent is fully constructed.\"\"\"\n",
+    "\n",
+    "    def register_hooks(self, registry: HookRegistry) -> None:\n",
+    "        registry.add_callback(AgentInitializedEvent, self._on_init)\n",
+    "\n",
+    "    def _on_init(self, event: AgentInitializedEvent) -> None:\n",
+    "        print(f\"agent initialized: model={type(event.agent.model).__name__}\")\n",
+    "\n",
+    "# Option A: pass at construction time.\n",
+    "agent_a = Agent(model=MODEL_ID, hooks=[StartupLogger()], callback_handler=None)\n",
+    "\n",
+    "# Option B: attach after construction with agent.hooks.add_hook.\n",
+    "agent_b = Agent(model=MODEL_ID, callback_handler=None)\n",
+    "agent_b.hooks.add_hook(StartupLogger())  # Note: AgentInitializedEvent has already\n",
+    "                                          # fired for agent_b, so this callback will\n",
+    "                                          # not run. Construction-time registration\n",
+    "                                          # is required to observe initialization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab914f8d",
+   "metadata": {},
+   "source": [
+    "## 2. The full event lifecycle\n",
+    "\n",
+    "To see the real ordering, attach a hook to every event type and print them in the order they fire. We will also add a tool so the tool events actually emit.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18c68cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def get_weather(city: str) -> str:\n",
+    "    \"\"\"Return the current weather for a city.\n",
+    "\n",
+    "    Args:\n",
+    "        city: City name.\n",
+    "    \"\"\"\n",
+    "    fake = {\"Seattle\": \"rainy, 52F\", \"Austin\": \"sunny, 78F\"}\n",
+    "    return fake.get(city, \"clear, 70F\")\n",
+    "\n",
+    "trace: list[str] = []\n",
+    "\n",
+    "def log(name):\n",
+    "    def cb(event):\n",
+    "        trace.append(name)\n",
+    "    return cb\n",
+    "\n",
+    "agent = Agent(model=MODEL_ID, tools=[get_weather], callback_handler=None)\n",
+    "\n",
+    "# Register one logger per event type. add_hook also accepts (callback, EventType).\n",
+    "for event_type in (\n",
+    "    BeforeInvocationEvent,\n",
+    "    MessageAddedEvent,\n",
+    "    BeforeModelCallEvent,\n",
+    "    AfterModelCallEvent,\n",
+    "    BeforeToolCallEvent,\n",
+    "    AfterToolCallEvent,\n",
+    "    AfterInvocationEvent,\n",
+    "):\n",
+    "    agent.add_hook(log(event_type.__name__), event_type)\n",
+    "\n",
+    "agent(\"What's the weather in Seattle?\")\n",
+    "\n",
+    "for i, name in enumerate(trace):\n",
+    "    print(f\"{i:2d}. {name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b1a8ba3",
+   "metadata": {},
+   "source": [
+    "You should see the ordering promised at the top of the notebook:\n",
+    "\n",
+    "```\n",
+    "BeforeInvocationEvent\n",
+    "MessageAddedEvent            <-- user turn\n",
+    "BeforeModelCallEvent\n",
+    "AfterModelCallEvent\n",
+    "MessageAddedEvent            <-- assistant turn requesting the tool\n",
+    "BeforeToolCallEvent\n",
+    "AfterToolCallEvent\n",
+    "MessageAddedEvent            <-- tool result\n",
+    "BeforeModelCallEvent         <-- model sees the tool result, produces the final answer\n",
+    "AfterModelCallEvent\n",
+    "MessageAddedEvent\n",
+    "AfterInvocationEvent\n",
+    "```\n",
+    "\n",
+    "The model/tool cycle repeats as many times as the model needs before stopping. `AfterInvocationEvent` fires exactly once at the end.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dca1f9ee",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "You now know:\n",
+    "\n",
+    "- How to register a hook four ways: `agent.add_hook(fn)` (type inferred), `agent.add_hook(fn, EventType)`, `hooks=[Provider()]` in the constructor, and `agent.hooks.add_hook(Provider())` after construction.\n",
+    "- The exact order of hook events in a Strands invocation, including the `After*` reverse-ordering rule.\n",
+    "- That `AgentInitializedEvent` fires once at construction time for one-time setup.\n",
+    "\n",
+    "### Next\n",
+    "\n",
+    "- [**02_hooks_intercept.ipynb**](./02_hooks_intercept.ipynb) - writable fields that let hooks block tools, retry failed calls, auto-continue the agent, and redact input.\n",
+    "- [**03_hooks_packaging.ipynb**](./03_hooks_packaging.ipynb) - cross-hook data sharing with `invocation_state` and bundling hooks into reusable `HookProvider` classes.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c432f445-83ac-4a4c-8520-10ec37392e57",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/01-learn/16-hooks-lifecycle/02_hooks_intercept.ipynb
+++ b/python/01-learn/16-hooks-lifecycle/02_hooks_intercept.ipynb
@@ -1,0 +1,341 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "30e03d51",
+   "metadata": {},
+   "source": [
+    "# Hooks Intercept: Writable Fields That Control Agent Behavior\n",
+    "\n",
+    "Most hook event attributes are read-only. A small set of fields are writable by design and change agent behavior when set. This notebook demonstrates the four most useful ones:\n",
+    "\n",
+    "- **`cancel_tool`** on `BeforeToolCallEvent` - block a tool and return a message to the model.\n",
+    "- **`retry`** on `AfterToolCallEvent` - re-run a failed tool call.\n",
+    "- **`resume`** on `AfterInvocationEvent` - auto-continue the agent with a follow-up prompt.\n",
+    "- **`messages`** on `BeforeInvocationEvent` - redact or rewrite input before the model sees it.\n",
+    "\n",
+    "Every example is self-contained and runnable.\n",
+    "\n",
+    "> **Previous:** [01_hooks_basics.ipynb](./01_hooks_basics.ipynb) covers registration and the event lifecycle.  \n",
+    "> **Next:** [03_hooks_packaging.ipynb](./03_hooks_packaging.ipynb) covers cross-hook data sharing and bundling hooks into reusable providers.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "field-table",
+   "metadata": {},
+   "source": [
+    "## Writable fields reference\n",
+    "\n",
+    "| Field | Event | Effect |\n",
+    "|-------|-------|--------|\n",
+    "| `cancel_tool` | `BeforeToolCallEvent` | Skip the tool; return the given string to the model as the tool result. |\n",
+    "| `selected_tool` / `tool_use` | `BeforeToolCallEvent` | Swap the tool or edit its arguments before execution. |\n",
+    "| `result` | `AfterToolCallEvent` | Rewrite the tool result the model will see. |\n",
+    "| `retry` | `AfterToolCallEvent` | Re-invoke the same tool call with the same `tool_use_id`. |\n",
+    "| `retry` | `AfterModelCallEvent` | Re-invoke the model with the same inputs. |\n",
+    "| `resume` | `AfterInvocationEvent` | Auto-start a new agent invocation with the given input. |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a38c3367",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "This tutorial uses Claude Haiku 4.5 on Amazon Bedrock by default. It works with any Strands-supported model. Swap the `model=` argument in the `Agent(...)` constructor if you prefer a different provider (see [Model Providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/)).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54dfbb09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -r requirements.txt --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "469e7218",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import re\n",
+    "\n",
+    "from strands import Agent, tool\n",
+    "from strands.hooks import (\n",
+    "    BeforeInvocationEvent,\n",
+    "    AfterInvocationEvent,\n",
+    "    AfterModelCallEvent,\n",
+    "    BeforeToolCallEvent,\n",
+    "    AfterToolCallEvent,\n",
+    "    HookProvider,\n",
+    "    HookRegistry,\n",
+    ")\n",
+    "\n",
+    "# Use the same Bedrock inference profile as the other 01-learn tutorials.\n",
+    "MODEL_ID = \"us.anthropic.claude-haiku-4-5-20251001-v1:0\"\n",
+    "\n",
+    "# Quiet SDK logs so the hook demonstrations stay the focus of the output.\n",
+    "logging.getLogger(\"strands\").setLevel(logging.WARNING)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "94aee32d",
+   "metadata": {},
+   "source": [
+    "## 1. `cancel_tool`: block a tool with a message to the model\n",
+    "\n",
+    "Set `event.cancel_tool = \"...message...\"` inside a `BeforeToolCallEvent` callback. The tool never runs; the string you set becomes the tool result the model sees.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec97316c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def send_email(to: str, body: str) -> str:\n",
+    "    \"\"\"Send an email.\n",
+    "\n",
+    "    Args:\n",
+    "        to: Recipient address.\n",
+    "        body: Email body.\n",
+    "    \"\"\"\n",
+    "    return f\"Email sent to {to}\"\n",
+    "\n",
+    "def block_external_email(event: BeforeToolCallEvent) -> None:\n",
+    "    if event.tool_use[\"name\"] == \"send_email\":\n",
+    "        recipient = event.tool_use[\"input\"].get(\"to\", \"\")\n",
+    "        if not recipient.endswith(\"@example.com\"):\n",
+    "            event.cancel_tool = (\n",
+    "                f\"Policy: cannot email external address {recipient!r}. \"\n",
+    "                \"Tell the user you can only email @example.com addresses.\"\n",
+    "            )\n",
+    "\n",
+    "agent = Agent(model=MODEL_ID, tools=[send_email], callback_handler=None)\n",
+    "agent.add_hook(block_external_email)\n",
+    "\n",
+    "print(agent(\"Email alice@gmail.com saying hi.\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd737bda",
+   "metadata": {},
+   "source": [
+    "The model receives our policy message as the tool result and responds by explaining the restriction. The external email was never actually sent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8dcc7ba2",
+   "metadata": {},
+   "source": [
+    "## 2. `retry` on `AfterToolCallEvent`: re-run a flaky tool\n",
+    "\n",
+    "Setting `event.retry = True` in an `AfterToolCallEvent` callback causes the tool executor to discard the result and re-invoke the tool with the same `tool_use_id`. Always pair this with a counter to bound retries.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c3fe7ad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class FlakyCounter:\n",
+    "    \"\"\"Deterministic flakiness: fail the first N calls, succeed afterwards.\"\"\"\n",
+    "    def __init__(self, fail_first: int = 1):\n",
+    "        self.calls = 0\n",
+    "        self.fail_first = fail_first\n",
+    "\n",
+    "counter = FlakyCounter(fail_first=1)\n",
+    "\n",
+    "@tool\n",
+    "def lookup_stock(symbol: str) -> str:\n",
+    "    \"\"\"Look up a stock price.\n",
+    "\n",
+    "    Args:\n",
+    "        symbol: Ticker symbol.\n",
+    "    \"\"\"\n",
+    "    counter.calls += 1\n",
+    "    if counter.calls <= counter.fail_first:\n",
+    "        raise RuntimeError(\"transient upstream error\")\n",
+    "    return f\"{symbol} is $142.10\"\n",
+    "\n",
+    "class RetryOnToolError(HookProvider):\n",
+    "    def __init__(self, max_retries: int = 2):\n",
+    "        self.max_retries = max_retries\n",
+    "        self.attempts: dict[str, int] = {}\n",
+    "\n",
+    "    def register_hooks(self, registry: HookRegistry) -> None:\n",
+    "        registry.add_callback(AfterToolCallEvent, self._maybe_retry)\n",
+    "\n",
+    "    def _maybe_retry(self, event: AfterToolCallEvent) -> None:\n",
+    "        tool_use_id = str(event.tool_use.get(\"toolUseId\", \"\"))\n",
+    "        self.attempts[tool_use_id] = self.attempts.get(tool_use_id, 0) + 1\n",
+    "        if event.result.get(\"status\") == \"error\" and self.attempts[tool_use_id] <= self.max_retries:\n",
+    "            print(f\"  retrying tool (attempt {self.attempts[tool_use_id]})\")\n",
+    "            event.retry = True\n",
+    "\n",
+    "agent = Agent(model=MODEL_ID, tools=[lookup_stock], hooks=[RetryOnToolError()], callback_handler=None)\n",
+    "print(agent(\"What is the price of ACME?\"))\n",
+    "print(\"tool was invoked\", counter.calls, \"times\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a4d6724f",
+   "metadata": {},
+   "source": [
+    "The first call raised; the `AfterToolCallEvent` hook flipped `retry = True`; the tool executor re-ran the tool with the same arguments; the retry succeeded and the model continued normally. Only the final (successful) result is added to conversation history.\n",
+    "\n",
+    "The same pattern works for `AfterModelCallEvent.retry`: inspect `event.exception` and set `event.retry = True` to re-run the model call (useful for handling throttling or transient model errors).\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "770e4eca",
+   "metadata": {},
+   "source": [
+    "**Two retry caveats to know:**\n",
+    "\n",
+    "* **Streaming:** intermediate streaming events (`ToolStreamEvent`, model deltas) from the discarded attempt have **already** been emitted to any caller consuming `stream_async`. Only the final attempt's result is added to conversation history. Callers processing streamed events should be idempotent or track the current attempt.\n",
+    "* **`structured_output`:** `BeforeModelCallEvent` / `AfterModelCallEvent` (and thus model-level `retry`) do **not** fire for `Agent.structured_output(...)`. Use `BeforeInvocationEvent` / `AfterInvocationEvent` if you need to hook that code path.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1858b05",
+   "metadata": {},
+   "source": [
+    "## 3. `resume` on `AfterInvocationEvent`: auto-continue the agent\n",
+    "\n",
+    "`AfterInvocationEvent.resume` lets a hook chain a follow-up invocation automatically. Set it to any valid agent input (string, message list, interrupt responses). Guard it with a termination condition to avoid infinite loops.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ed1c69f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "summarize_done = {\"done\": False}\n",
+    "\n",
+    "async def summarize_once(event: AfterInvocationEvent) -> None:\n",
+    "    if not summarize_done[\"done\"] and event.result and event.result.stop_reason == \"end_turn\":\n",
+    "        summarize_done[\"done\"] = True\n",
+    "        event.resume = \"Now summarize what you just said in exactly five words.\"\n",
+    "\n",
+    "agent = Agent(model=MODEL_ID, callback_handler=None)\n",
+    "agent.add_hook(summarize_once)\n",
+    "\n",
+    "result = agent(\"List three benefits of typed hook systems.\")\n",
+    "print(\"final answer:\", str(result).strip())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "958a3285",
+   "metadata": {},
+   "source": [
+    "The agent runs twice inside a single top-level `agent(...)` call: once to produce the list, and a second time (triggered by `resume`) to produce the five-word summary. A fresh `BeforeInvocationEvent` fires for the second pass, so the lifecycle is fully re-entered.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9841b47b",
+   "metadata": {},
+   "source": [
+    "## 4. `BeforeInvocationEvent.messages`: redact input before the model sees it\n",
+    "\n",
+    "`BeforeInvocationEvent` exposes a writable `messages` field. Mutating it rewrites what the agent processes for this request, without touching any previous conversation history. This is the clean place to strip PII, redact secrets, or normalize user input.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a832f717",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "EMAIL_RE = re.compile(r\"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\")\n",
+    "\n",
+    "def redact_emails(event: BeforeInvocationEvent) -> None:\n",
+    "    if not event.messages:\n",
+    "        return\n",
+    "    for msg in event.messages:\n",
+    "        for block in msg.get(\"content\", []):\n",
+    "            if \"text\" in block:\n",
+    "                block[\"text\"] = EMAIL_RE.sub(\"[REDACTED_EMAIL]\", block[\"text\"])\n",
+    "\n",
+    "agent = Agent(model=MODEL_ID, callback_handler=None)\n",
+    "agent.add_hook(redact_emails)\n",
+    "\n",
+    "print(agent(\"Did you get a message from alice@example.com this morning?\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f88e8fb",
+   "metadata": {},
+   "source": [
+    "The model never sees the literal email address; it sees `[REDACTED_EMAIL]`. The same pattern works for secrets, account numbers, or any content you would rather not send to the model.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dca1f9ee",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "You now know how to use the writable fields that let hooks control agent behavior:\n",
+    "\n",
+    "- `cancel_tool` to block a tool and return a policy message.\n",
+    "- `retry` to re-run a failed tool (or model) call with bounded retries.\n",
+    "- `resume` to auto-chain a follow-up invocation.\n",
+    "- `messages` to redact or rewrite input before the model processes it.\n",
+    "\n",
+    "### Next\n",
+    "\n",
+    "- [**03_hooks_packaging.ipynb**](./03_hooks_packaging.ipynb) - share data across hooks with `invocation_state` and bundle multiple hooks into a reusable `HookProvider`.\n",
+    "\n",
+    "### See also\n",
+    "\n",
+    "- [**`13-human-in-the-loop`**](../13-human-in-the-loop/) - `BeforeToolCallEvent` is also `_Interruptible`: hooks can raise interrupts that pause the agent for human input.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/01-learn/16-hooks-lifecycle/03_hooks_packaging.ipynb
+++ b/python/01-learn/16-hooks-lifecycle/03_hooks_packaging.ipynb
@@ -1,0 +1,362 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "15742a44",
+   "metadata": {},
+   "source": [
+    "# Hooks Packaging: Data Sharing and Reusable Providers\n",
+    "\n",
+    "When hooks need to share data within a single invocation, or when you want to ship a bundle of hooks as one unit, Strands provides two mechanisms:\n",
+    "\n",
+    "1. **`invocation_state`** - a per-request dict that any hook can read and write during one `agent(...)` call.\n",
+    "2. **`HookProvider`** - a class that groups related callbacks so they register and ship together.\n",
+    "\n",
+    "This notebook covers both patterns and finishes with a combined example that ties together everything from the series.\n",
+    "\n",
+    "> **Previous:** [01_hooks_basics.ipynb](./01_hooks_basics.ipynb) covers registration and the event lifecycle. [02_hooks_intercept.ipynb](./02_hooks_intercept.ipynb) covers writable fields for blocking, retrying, and resuming.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a38c3367",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "\n",
+    "This tutorial uses Claude Haiku 4.5 on Amazon Bedrock by default. It works with any Strands-supported model. Swap the `model=` argument in the `Agent(...)` constructor if you prefer a different provider (see [Model Providers](https://strandsagents.com/docs/user-guide/concepts/model-providers/)).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54dfbb09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -r requirements.txt --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "469e7218",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import time\n",
+    "import uuid\n",
+    "\n",
+    "from strands import Agent, tool\n",
+    "from strands.hooks import (\n",
+    "    BeforeInvocationEvent,\n",
+    "    AfterInvocationEvent,\n",
+    "    AfterModelCallEvent,\n",
+    "    BeforeToolCallEvent,\n",
+    "    AfterToolCallEvent,\n",
+    "    HookProvider,\n",
+    "    HookRegistry,\n",
+    ")\n",
+    "\n",
+    "# Use the same Bedrock inference profile as the other 01-learn tutorials.\n",
+    "MODEL_ID = \"us.anthropic.claude-haiku-4-5-20251001-v1:0\"\n",
+    "\n",
+    "# Quiet SDK logs so the hook demonstrations stay the focus of the output.\n",
+    "logging.getLogger(\"strands\").setLevel(logging.WARNING)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tool-def",
+   "metadata": {},
+   "source": [
+    "We will reuse a simple weather tool throughout this notebook.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "tool-cell",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def get_weather(city: str) -> str:\n",
+    "    \"\"\"Return the current weather for a city.\n",
+    "\n",
+    "    Args:\n",
+    "        city: City name.\n",
+    "    \"\"\"\n",
+    "    fake = {\"Seattle\": \"rainy, 52F\", \"Austin\": \"sunny, 78F\"}\n",
+    "    return fake.get(city, \"clear, 70F\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "section1-intro",
+   "metadata": {},
+   "source": [
+    "## 1. Cross-hook data sharing within a single invocation\n",
+    "\n",
+    "Every hook event exposes an `invocation_state` dict scoped to exactly one top-level `agent(...)` call. It is the right place to share per-request context (correlation IDs, timers, counters, open connections) across hooks.\n",
+    "\n",
+    "Two complementary patterns:\n",
+    "\n",
+    "1. **Stateless callbacks + `invocation_state`** - write from a `Before*` hook, read from the matching `After*` hook. Survives concurrent invocations because each call gets its own dict.\n",
+    "2. **`HookProvider` instance state** - store data on `self`. Convenient when callbacks need shared configuration, but requires care if the same provider is used across concurrent invocations.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a46cdddc",
+   "metadata": {},
+   "source": [
+    "### 1a. Pattern 1: share through `invocation_state`\n",
+    "\n",
+    "`invocation_state` is populated from kwargs you pass to `agent(...)` plus anything hooks write to it. Any hook fired during the same invocation sees the same dict.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8185fac8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tag_request(event: BeforeInvocationEvent) -> None:\n",
+    "    event.invocation_state[\"request_id\"] = uuid.uuid4().hex[:8]\n",
+    "    event.invocation_state[\"t0\"] = time.perf_counter()\n",
+    "    event.invocation_state[\"model_calls\"] = 0\n",
+    "    event.invocation_state[\"tool_calls\"] = 0\n",
+    "\n",
+    "def count_model(event: AfterModelCallEvent) -> None:\n",
+    "    event.invocation_state[\"model_calls\"] += 1\n",
+    "\n",
+    "def count_tool(event: AfterToolCallEvent) -> None:\n",
+    "    event.invocation_state[\"tool_calls\"] += 1\n",
+    "\n",
+    "def report(event: AfterInvocationEvent) -> None:\n",
+    "    s = event.invocation_state\n",
+    "    elapsed = time.perf_counter() - s[\"t0\"]\n",
+    "    print(\n",
+    "        f\"[{s['request_id']}] finished in {elapsed:.2f}s \"\n",
+    "        f\"({s['model_calls']} model calls, {s['tool_calls']} tool calls)\"\n",
+    "    )\n",
+    "\n",
+    "agent = Agent(model=MODEL_ID, tools=[get_weather], callback_handler=None)\n",
+    "for cb in (tag_request, count_model, count_tool, report):\n",
+    "    agent.add_hook(cb)\n",
+    "\n",
+    "agent(\"What is the weather in Austin?\")\n",
+    "_ = agent(\"And in Seattle?\")  # suppress AgentResult repr in notebook output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b95af4a",
+   "metadata": {},
+   "source": [
+    "Each line in the output shows a distinct correlation ID because `invocation_state` is freshly created per call.\n",
+    "\n",
+    "You can also seed `invocation_state` from the caller:\n",
+    "\n",
+    "```python\n",
+    "agent(\"Process the data\", user_id=\"user123\", session_id=\"sess456\")\n",
+    "# Inside any hook: event.invocation_state[\"user_id\"]  -> \"user123\"\n",
+    "```\n",
+    "\n",
+    "This is the right channel for non-JSON-serializable objects like database connections. Those cannot live in `agent.state`, but they flow through `invocation_state` without restriction.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2207d00",
+   "metadata": {},
+   "source": [
+    "### 1b. Pattern 2: `HookProvider` with instance state\n",
+    "\n",
+    "When you have a cohesive hook with its own configuration, package it as a `HookProvider`. The class holds configuration and (when appropriate) per-invocation counters initialized in `BeforeInvocationEvent`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7f53dc1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class PerInvocationToolBudget(HookProvider):\n",
+    "    \"\"\"Cap total tool calls per invocation. Resets at the start of each call.\"\"\"\n",
+    "\n",
+    "    def __init__(self, max_tools: int = 3):\n",
+    "        self.max_tools = max_tools\n",
+    "        self.used = 0\n",
+    "\n",
+    "    def register_hooks(self, registry: HookRegistry) -> None:\n",
+    "        registry.add_callback(BeforeInvocationEvent, self._reset)\n",
+    "        registry.add_callback(BeforeToolCallEvent, self._enforce)\n",
+    "\n",
+    "    def _reset(self, event: BeforeInvocationEvent) -> None:\n",
+    "        self.used = 0\n",
+    "\n",
+    "    def _enforce(self, event: BeforeToolCallEvent) -> None:\n",
+    "        self.used += 1\n",
+    "        if self.used > self.max_tools:\n",
+    "            event.cancel_tool = (\n",
+    "                f\"Tool budget of {self.max_tools} exceeded for this request. \"\n",
+    "                \"Stop calling tools and answer with what you have.\"\n",
+    "            )\n",
+    "\n",
+    "agent = Agent(\n",
+    "    model=MODEL_ID,\n",
+    "    tools=[get_weather],\n",
+    "    hooks=[PerInvocationToolBudget(max_tools=2)],\n",
+    "    callback_handler=None,\n",
+    ")\n",
+    "print(agent(\"Give me weather for Seattle, Austin, Portland, and Boise.\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec6ed89a",
+   "metadata": {},
+   "source": [
+    "The provider enforces a hard ceiling of two tool calls per `agent(...)`. The model gets a cancel message on any further tool attempt and has to answer with what it has.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "db62e60b",
+   "metadata": {},
+   "source": [
+    "## 2. Packaging multiple hooks into one `HookProvider`\n",
+    "\n",
+    "A `HookProvider` groups related callbacks so they ship as a single unit. Passing one to the agent constructor (`hooks=[MyProvider()]`) calls its `register_hooks` method for you.\n",
+    "\n",
+    "Below we combine everything from this series (per-request tagging, model/tool counters, a tool budget, and a single-shot summary resume) into one observability and control plugin.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "caa0085b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class LifecycleObserver(HookProvider):\n",
+    "    \"\"\"One-stop observer: request IDs, call counts, tool budget, auto-summary.\"\"\"\n",
+    "\n",
+    "    def __init__(self, max_tools: int = 5, summarize: bool = False):\n",
+    "        self.max_tools = max_tools\n",
+    "        self.summarize = summarize\n",
+    "        # Guard must live on the instance, not on invocation_state,\n",
+    "        # because invocation_state is recreated on every (including resumed) invocation.\n",
+    "        self._summarized = False\n",
+    "\n",
+    "    def register_hooks(self, registry: HookRegistry) -> None:\n",
+    "        registry.add_callback(BeforeInvocationEvent, self._start)\n",
+    "        registry.add_callback(AfterModelCallEvent, self._on_model)\n",
+    "        registry.add_callback(BeforeToolCallEvent, self._on_tool_before)\n",
+    "        registry.add_callback(AfterToolCallEvent, self._on_tool_after)\n",
+    "        registry.add_callback(AfterInvocationEvent, self._finish)\n",
+    "\n",
+    "    def _start(self, event: BeforeInvocationEvent) -> None:\n",
+    "        event.invocation_state.update(\n",
+    "            request_id=uuid.uuid4().hex[:8],\n",
+    "            t0=time.perf_counter(),\n",
+    "            model_calls=0,\n",
+    "            tool_calls=0,\n",
+    "        )\n",
+    "\n",
+    "    def _on_model(self, event: AfterModelCallEvent) -> None:\n",
+    "        event.invocation_state[\"model_calls\"] += 1\n",
+    "\n",
+    "    def _on_tool_before(self, event: BeforeToolCallEvent) -> None:\n",
+    "        if event.invocation_state.get(\"tool_calls\", 0) >= self.max_tools:\n",
+    "            event.cancel_tool = f\"Tool budget of {self.max_tools} exceeded.\"\n",
+    "\n",
+    "    def _on_tool_after(self, event: AfterToolCallEvent) -> None:\n",
+    "        event.invocation_state[\"tool_calls\"] += 1\n",
+    "\n",
+    "    async def _finish(self, event: AfterInvocationEvent) -> None:\n",
+    "        s = event.invocation_state\n",
+    "        print(\n",
+    "            f\"[{s['request_id']}] {time.perf_counter() - s['t0']:.2f}s \"\n",
+    "            f\"model={s['model_calls']} tools={s['tool_calls']}\"\n",
+    "        )\n",
+    "        if (\n",
+    "            self.summarize\n",
+    "            and not self._summarized\n",
+    "            and event.result\n",
+    "            and event.result.stop_reason == \"end_turn\"\n",
+    "        ):\n",
+    "            self._summarized = True\n",
+    "            event.resume = \"Summarize your previous answer in one sentence.\"\n",
+    "\n",
+    "agent = Agent(\n",
+    "    model=MODEL_ID,\n",
+    "    tools=[get_weather],\n",
+    "    hooks=[LifecycleObserver(max_tools=3, summarize=True)],\n",
+    "    callback_handler=None,\n",
+    ")\n",
+    "print(agent(\"Look up the weather in Seattle.\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3302a689",
+   "metadata": {},
+   "source": [
+    "One class, five hook types, reusable across agents. This is the idiomatic way to ship cross-cutting agent behavior: logging, metrics, policy, rate-limiting, etc.\n",
+    "\n",
+    "For larger bundles that also want to contribute tools, system prompt fragments, or configuration, use the [`Plugin`](https://strandsagents.com/docs/user-guide/concepts/plugins/) API, which wraps `HookProvider` with additional packaging.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dca1f9ee",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "Across this three-notebook series you have learned:\n",
+    "\n",
+    "- The exact order of hook events in a Strands invocation, including the `After*` reverse-ordering rule ([01_hooks_basics](./01_hooks_basics.ipynb)).\n",
+    "- How to register a hook four ways: `agent.add_hook(fn)` (type inferred), `agent.add_hook(fn, EventType)`, `hooks=[Provider()]` in the constructor, and `agent.hooks.add_hook(Provider())` after construction ([01_hooks_basics](./01_hooks_basics.ipynb)).\n",
+    "- The writable fields that let hooks control the agent: `BeforeInvocationEvent.messages`, `cancel_tool`, `selected_tool`, `tool_use`, `result`, `retry` (after model / after tool), and `resume` ([02_hooks_intercept](./02_hooks_intercept.ipynb)).\n",
+    "- Two patterns for sharing data between hooks in one invocation: `invocation_state` (stateless callbacks) and `HookProvider` instance state.\n",
+    "- How to bundle multiple hooks into one reusable provider.\n",
+    "- That `structured_output` does not fire model-call events, and that retries may emit streaming events from discarded attempts.\n",
+    "\n",
+    "### See also\n",
+    "\n",
+    "- [**`13-human-in-the-loop`**](../13-human-in-the-loop/) - `BeforeToolCallEvent` is also `_Interruptible`: hooks can raise interrupts that pause the agent for human input.\n",
+    "- **Multi-agent hooks** - `BeforeMultiAgentInvocationEvent`, `BeforeNodeCallEvent` (with writable `cancel_node`), `AfterNodeCallEvent`, etc. Same mental model as single-agent hooks, but fired by `Graph` / `Swarm` orchestrators. See the [hooks concept guide](https://strandsagents.com/docs/user-guide/concepts/agents/hooks/).\n",
+    "- [**Plugins**](https://strandsagents.com/docs/user-guide/concepts/plugins/) - package hook bundles with tools, system-prompt fragments, and config as installable units.\n",
+    "- [**`08-observability`**](../08-observability/) - production tracing built on the same hook surface.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/python/01-learn/16-hooks-lifecycle/README.md
+++ b/python/01-learn/16-hooks-lifecycle/README.md
@@ -1,0 +1,109 @@
+# The Agent Hooks Lifecycle with Strands Agents
+
+This tutorial is a hands-on tour of the Strands Agents **hooks** system, the composable, type-safe extension point that fires callbacks throughout an agent's request lifecycle. By the end, you will know where every hook fires, how to register one, and how to use writable hook fields (`messages`, `cancel_tool`, `retry`, `resume`) to control agent behavior at runtime.
+
+## Tutorial Details
+
+| Information          | Details                                                                 |
+|----------------------|-------------------------------------------------------------------------|
+| **Strands Features** | Hooks, `HookProvider`, `AgentInitializedEvent`, `BeforeInvocationEvent`, `AfterInvocationEvent`, `BeforeModelCallEvent`, `AfterModelCallEvent`, `BeforeToolCallEvent`, `AfterToolCallEvent`, `MessageAddedEvent`, `invocation_state` |
+| **Agent Pattern**    | Single agent with lifecycle observers and interceptors                  |
+| **Tools**            | Small custom tools used to exercise the tool events                     |
+| **Model**            | Claude Haiku 4.5 on Amazon Bedrock (any Strands-supported model works)  |
+
+## What You'll Learn
+
+The tutorial is split into three sequential notebooks, each self-contained and independently runnable:
+
+1. [**01_hooks_basics.ipynb**](./01_hooks_basics.ipynb) - Register callbacks for `BeforeModelCallEvent` and `AfterModelCallEvent` with `agent.add_hook()` to measure model latency, use `AgentInitializedEvent` for one-time setup, and trace the full event lifecycle across model and tool calls.
+2. [**02_hooks_intercept.ipynb**](./02_hooks_intercept.ipynb) - Use `BeforeToolCallEvent.cancel_tool` to block a tool, `AfterToolCallEvent.retry` to re-run a failed call, `AfterInvocationEvent.resume` to auto-continue the agent, and `BeforeInvocationEvent.messages` to redact input before the model sees it.
+3. [**03_hooks_packaging.ipynb**](./03_hooks_packaging.ipynb) - Pass per-invocation context between hooks via `invocation_state`, package hooks into a reusable `HookProvider` class, and combine everything into a single observability and control plugin.
+
+## Lifecycle Diagram
+
+```
+Agent(...)  ──►  AgentInitializedEvent                   (once, at construction)
+
+agent("Summarize the weather in Seattle")
+│
+├─ BeforeInvocationEvent              (once per request)
+│  │                                    writable: messages
+│  └─ MessageAddedEvent  (user input added to history)
+│
+├─ BeforeModelCallEvent               (each time the model is invoked)
+│  └─ AfterModelCallEvent             writable: retry
+│     └─ MessageAddedEvent (model's assistant turn)
+│
+├─ BeforeToolCallEvent                (for every tool the model requests)
+│  │                                    writable: cancel_tool, selected_tool, tool_use
+│  └─ AfterToolCallEvent              writable: result, retry  (reverse order)
+│     └─ MessageAddedEvent (tool result appended)
+│
+├─ (loop: BeforeModelCall → AfterModelCall → tool calls → ... until end_turn)
+│
+└─ AfterInvocationEvent               (once per request, reverse order)
+                                         writable: resume
+```
+
+## Prerequisites
+
+- Python 3.10 or later.
+- An AWS account with [Amazon Bedrock](https://aws.amazon.com/bedrock/) model access (Claude Haiku 4.5 by default; see the notebook for how to swap models).
+- Basic familiarity with Strands Agents ([Quickstart Guide](https://strandsagents.com/latest/documentation/docs/user-guide/quickstart/)).
+
+## Tutorial Structure
+
+```
+16-hooks-lifecycle/
+├── README.md
+├── requirements.txt
+├── 01_hooks_basics.ipynb
+├── 02_hooks_intercept.ipynb
+└── 03_hooks_packaging.ipynb
+```
+
+| File                                                       | Description                                                              |
+|------------------------------------------------------------|--------------------------------------------------------------------------|
+| [01_hooks_basics.ipynb](./01_hooks_basics.ipynb)           | Your first hook and the full event lifecycle.                            |
+| [02_hooks_intercept.ipynb](./02_hooks_intercept.ipynb)     | Writable fields: cancel, retry, resume, and redaction.                   |
+| [03_hooks_packaging.ipynb](./03_hooks_packaging.ipynb)     | Cross-hook data sharing and reusable `HookProvider` packaging.           |
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Examples
+
+1. Start with [01_hooks_basics.ipynb](./01_hooks_basics.ipynb) and work through the notebooks in order.
+2. Each notebook is self-contained: run cells sequentially within any single notebook.
+
+## Key Concepts
+
+- **Hook**: a typed callback the agent invokes when a specific lifecycle event fires.
+- **HookEvent**: a strongly-typed event object carrying data for that lifecycle stage. Most fields are read-only; a handful are intentionally writable to let hooks control agent behavior.
+- **HookProvider**: a class that bundles multiple callbacks so you can ship hooks as reusable components.
+- **`invocation_state`**: a per-invocation dictionary every hook event exposes. It is the clean way to share data between hooks within a single request.
+- **Reverse ordering**: `After*Event` callbacks fire in reverse registration order so outer hooks see inner hooks' side-effects (think `try/finally`).
+
+## Important Notes
+
+- Hook callbacks may be synchronous or `async`. Strands will await async callbacks automatically.
+- Setting `AfterModelCallEvent.retry = True` or `AfterToolCallEvent.retry = True` causes the call to re-execute with the same inputs. Always pair retries with a counter to avoid infinite loops.
+- `AfterInvocationEvent.resume` triggers a brand-new invocation cycle (including a fresh `BeforeInvocationEvent`); guard it with a termination condition held on your `HookProvider` instance, not in `invocation_state` (which resets on each new invocation).
+- `Agent.structured_output(...)` does **not** fire `BeforeModelCallEvent` or `AfterModelCallEvent`. Use `BeforeInvocationEvent` / `AfterInvocationEvent` if you need to hook that code path.
+- When a retry is requested, intermediate streaming events from the discarded attempt have already been emitted to `stream_async` consumers. Only the final attempt's result is added to conversation history.
+
+## Additional Resources
+
+- [Hooks Concept Guide](https://strandsagents.com/docs/user-guide/concepts/agents/hooks/)
+- [`strands.hooks.events` API reference](https://strandsagents.com/docs/api/python/strands.hooks.events/)
+- [`strands.hooks.registry` API reference](https://strandsagents.com/docs/api/python/strands.hooks.registry/)
+- [Plugins](https://strandsagents.com/docs/user-guide/concepts/plugins/): package hooks plus tools plus config together.
+
+## Next Steps
+
+- See [`13-human-in-the-loop`](../13-human-in-the-loop/) for how interrupts compose with hooks (`BeforeToolCallEvent` is `_Interruptible`).
+- See [`08-observability`](../08-observability/) for production-grade tracing built on the same hook surface.
+- Explore **multi-agent hooks** (`BeforeMultiAgentInvocationEvent`, `BeforeNodeCallEvent`, `AfterNodeCallEvent`, and `cancel_node`) when moving to `Graph` or `Swarm` orchestration.

--- a/python/01-learn/16-hooks-lifecycle/requirements.txt
+++ b/python/01-learn/16-hooks-lifecycle/requirements.txt
@@ -1,0 +1,2 @@
+strands-agents
+strands-agents-tools

--- a/python/01-learn/README.md
+++ b/python/01-learn/README.md
@@ -20,6 +20,7 @@ Step-by-step guides from basic agent creation to multi-agent orchestration.
 | [`12-graph`](./12-graph/) | `GraphBuilder` | Create deterministic agent workflows |
 | [`13-human-in-the-loop`](./13-human-in-the-loop/) | Interrupts, hooks | Implement approval workflows with human oversight |
 | [`15-skills`](./15-skills/) | AgentSkills plugin, Skill dataclass | Load specialized instructions on demand with skills |
+| [`16-hooks-lifecycle`](./16-hooks-lifecycle/) | `HookProvider`, lifecycle events, `cancel_tool`, `retry`, `resume` | Tour the full hook lifecycle and use writable fields to control agent behavior |
 
 ## Getting Started
 


### PR DESCRIPTION
## Issue #, if available

N/A, new tutorial contribution.

## Description of changes

Adds a new learn-track tutorial at `python/01-learn/16-hooks-lifecycle/` covering the Strands Agents hooks system end to end. By the end of the notebook, a reader knows where every hook fires, how to register one, and how to use the writable hook fields to steer an agent at runtime.

**What the tutorial covers (five progressive sections):**

1. **Your first hook**: register callbacks for `BeforeModelCallEvent` and `AfterModelCallEvent` via `agent.add_hook()`, plus a `HookProvider` for `AgentInitializedEvent`.
2. **The full event lifecycle**: attach a tracer that prints the exact order of every event across model and tool calls.
3. **Writable fields**:
   - `BeforeToolCallEvent.cancel_tool`, block a tool and return a message to the model.
   - `AfterToolCallEvent.retry`, re-run a flaky tool (deterministic demo).
   - `AfterInvocationEvent.resume`, auto-continue with a follow-up invocation.
   - `BeforeInvocationEvent.messages`, redact input (PII) before the model sees it.
4. **Cross-hook data sharing**: `invocation_state` for stateless callbacks and `HookProvider` instance state for tool budgets.
5. **Packaging hooks**: one `LifecycleObserver` that combines observability plus policy plus resume-once.

**Files added:**
- `python/01-learn/16-hooks-lifecycle/hooks_lifecycle.ipynb`, 38 cells, all run cleanly end to end on `strands-agents` with Claude Haiku 4.5 on Bedrock.
- `python/01-learn/16-hooks-lifecycle/README.md`, prerequisites, lifecycle diagram, key concepts, important notes (including the `structured_output` and streaming-during-retry caveats), additional resources.
- `python/01-learn/16-hooks-lifecycle/requirements.txt`, `strands-agents`, `strands-agents-tools`.

**Index README:**
- `python/01-learn/README.md`, one new row `16-hooks-lifecycle` in the Index table.

## Screenshots (if appropriate)

N/A.

## Related Issues/PRs

N/A.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have run the notebook end to end on my machine with no errors.

## License

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
