### PR TITLE
fix(01-learn): replace yanked cdk-mcp-server with aws-iac-mcp-server

### DIFF
--- a/python/01-learn/02-tools-and-mcp/01-using-mcp-tools/mcp-agent.ipynb
+++ b/python/01-learn/02-tools-and-mcp/01-using-mcp-tools/mcp-agent.ipynb
@@ -357,7 +357,7 @@
     "    <img src=\"images/architecture_3.png\" width=\"85%\" />\n",
     "</div>\n",
     "\n",
-    "In this agent, we will again use the AWS Documentation MCP server and we will also use the [AWS CDK MCP Server](https://awslabs.github.io/mcp/servers/cdk-mcp-server/) which helps with AWS Cloud Development Kit (CDK) best practices, infrastructure as code patterns and security compliance with CDK Nag.\n",
+    "In this agent, we will again use the AWS Documentation MCP server and we will also use the [AWS IaC MCP Server](https://awslabs.github.io/mcp/servers/aws-iac-mcp-server/) which helps with AWS Cloud Development Kit (CDK) best practices, CloudFormation validation, infrastructure as code patterns and security compliance.\n",
     "\n",
     "First let's connect to the two MCP servers using the stdio transport"
    ]
@@ -377,10 +377,10 @@
     "    )\n",
     ")\n",
     "\n",
-    "# Connect to an MCP server using stdio transport\n",
-    "cdk_mcp_client = MCPClient(\n",
+    "# Connect to the AWS IaC MCP server using stdio transport\n",
+    "iac_mcp_client = MCPClient(\n",
     "    lambda: stdio_client(\n",
-    "        StdioServerParameters(command=\"uvx\", args=[\"awslabs.cdk-mcp-server@latest\"])\n",
+    "        StdioServerParameters(command=\"uvx\", args=[\"awslabs.aws-iac-mcp-server@latest\"])\n",
     "    )\n",
     ")"
    ]
@@ -401,9 +401,9 @@
    "outputs": [],
    "source": [
     "# Create an agent with MCP tools\n",
-    "with aws_docs_mcp_client, cdk_mcp_client:\n",
+    "with aws_docs_mcp_client, iac_mcp_client:\n",
     "    # Get the tools from the MCP server\n",
-    "    tools = aws_docs_mcp_client.list_tools_sync() + cdk_mcp_client.list_tools_sync()\n",
+    "    tools = aws_docs_mcp_client.list_tools_sync() + iac_mcp_client.list_tools_sync()\n",
     "\n",
     "    # Create an agent with these tools\n",
     "    agent = Agent(\n",


### PR DESCRIPTION
The awslabs.cdk-mcp-server package was yanked from PyPI and superseded by awslabs.aws-iac-mcp-server. This updates the MCP tools tutorial to use the replacement package.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
