### PR TITLE
Specify version constraint for mem0ai in requirements.txt

### DIFF
--- a/python/01-learn/06-memory/requirements.txt
+++ b/python/01-learn/06-memory/requirements.txt
@@ -1,6 +1,6 @@
 strands-agents
 strands-agents-tools
-mem0ai
+mem0ai<2.0
 boto3 
 opensearch-py
 ddgs


### PR DESCRIPTION
*Issue #, if available:* #262

*Description of changes:*
This PR adds version constraint of `<2.0` for `mem0ai` in `requirements.txt` as starting version 2.0.0 mem0ai throws `ValueError` as top-level entity parameters `frozenset({'user_id', 'agent_id'})` are no longer supported in `search()` and must reside inside `filters={"user_id": "..."}`. (See [breaking changes](https://github.com/mem0ai/mem0/releases/tag/v2.0.0#:~:text=Breaking%20changes%20at%20a%20glance))


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
