### PR TITLE
fix(18-self-improving-agents): repair AgentCore Memory setup for workshop

### DIFF
--- a/python/01-learn/18-self-improving-agents/README.md
+++ b/python/01-learn/18-self-improving-agents/README.md
@@ -16,7 +16,7 @@ Go from a 20-line Strands agent to a fully autonomous, self-improving agent depl
 | **Custom Tools**     | `system_prompt` (self-modification), `calculator` (example of a self-written tool)        |
 | **Memory**           | Amazon Bedrock AgentCore Memory (semantic, per-actor)                                     |
 | **Complexity**       | Beginner → Advanced (progressive)                                                         |
-| **Model Provider**   | Amazon Bedrock — Claude Sonnet 4.5 (`global.anthropic.claude-opus-4-8`)                  |
+| **Model Provider**   | Amazon Bedrock — Claude Opus 4 (`global.anthropic.claude-opus-4-8`)                  |
 | **SDK Used**         | Strands Agents SDK, `bedrock-agentcore`                                                   |
 
 ## The core pattern: Agent → Model → Tools
@@ -47,7 +47,7 @@ Every step reuses this one loop. Once you grok **Agent · Model · Tools**, ever
 ## Prerequisites
 
 - Python **3.10+** and `pip`
-- AWS account with [Amazon Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) enabled for Claude Sonnet 4.5 in `us-east-1`
+- AWS account with [Amazon Bedrock model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) enabled for Claude Opus 4 (`global.anthropic.claude-opus-4-8`) in `us-east-1`
 - AWS credentials configured (`aws configure` or environment variables)
 - For steps 3–5: [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) access
 - For step 5 deploy: Node.js 20+ (the new [`@aws/agentcore`](https://github.com/aws/agentcore-cli) CLI)

--- a/python/01-learn/18-self-improving-agents/code/step-00-hello/README.md
+++ b/python/01-learn/18-self-improving-agents/code/step-00-hello/README.md
@@ -12,7 +12,7 @@ python agent.py "hello, what can you do?"
 ## What to notice
 
 - **One import**: `from strands import Agent`
-- **One model**: Claude 4.6 Sonnet via Bedrock
+- **One model**: Claude Opus 4 (`global.anthropic.claude-opus-4-8`) via Bedrock
 - **One tool**: `shell` from `strands_tools`
 - **Zero orchestration**: the agent decides when to call the tool
 

--- a/python/01-learn/18-self-improving-agents/code/step-00-hello/agent.py
+++ b/python/01-learn/18-self-improving-agents/code/step-00-hello/agent.py
@@ -1,6 +1,6 @@
 """AIM308 - Step 0: Hello Agent.
 
-The minimum viable Strands agent. Claude 4.6 Sonnet + one tool (shell).
+The minimum viable Strands agent. Claude Opus 4 + one tool (shell).
 """
 import sys
 from strands import Agent

--- a/python/01-learn/18-self-improving-agents/code/step-03-memory/create_memory.py
+++ b/python/01-learn/18-self-improving-agents/code/step-03-memory/create_memory.py
@@ -12,6 +12,10 @@ import boto3
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 NAME = os.environ.get("AIM308_MEMORY_NAME", "aim308_workshop_memory")
 
+# How long AgentCore retains raw events before expiry (in days). The
+# CreateMemory API requires this — omitting it raises ParamValidationError.
+EVENT_EXPIRY_DAYS = int(os.environ.get("AIM308_EVENT_EXPIRY_DAYS", "90"))
+
 
 def main():
     client = boto3.client("bedrock-agentcore-control", region_name=REGION)
@@ -20,7 +24,7 @@ def main():
     try:
         paginator = client.get_paginator("list_memories")
         for page in paginator.paginate():
-            for m in page.get("memorySummaries", []):
+            for m in page.get("memories", page.get("memorySummaries", [])):
                 if m.get("name") == NAME:
                     print(f"✅ Memory already exists: {m['id']}")
                     print(f"export BEDROCK_AGENTCORE_MEMORY_ID={m['id']}")
@@ -28,19 +32,30 @@ def main():
     except Exception as e:
         print(f"(list_memories failed: {e} - continuing to create)")
 
+    # Two built-in strategies, each writing to its OWN namespace:
+    #   - semanticMemoryStrategy      -> /users/{actorId}/facts
+    #   - userPreferenceMemoryStrategy -> /users/{actorId}/preferences
+    # The AgentCore API allows at most ONE namespace per strategy and ONE
+    # strategy of each type, so "facts" and "preferences" must be modeled as
+    # two different strategy types rather than two namespaces on one strategy.
+    # These namespaces match the agents' retrieval_config in agent.py.
     resp = client.create_memory(
         name=NAME,
         description="AIM308 NY Summit workshop - attendee long-term memory",
+        eventExpiryDuration=EVENT_EXPIRY_DAYS,
         memoryStrategies=[
             {
                 "semanticMemoryStrategy": {
-                    "name": "facts_and_preferences",
-                    "namespaces": [
-                        "/users/{actorId}/facts",
-                        "/users/{actorId}/preferences",
-                    ],
+                    "name": "facts",
+                    "namespaces": ["/users/{actorId}/facts"],
                 }
-            }
+            },
+            {
+                "userPreferenceMemoryStrategy": {
+                    "name": "preferences",
+                    "namespaces": ["/users/{actorId}/preferences"],
+                }
+            },
         ],
     )
     memory_id = resp["memory"]["id"]

--- a/python/01-learn/18-self-improving-agents/code/step-04-ambient/create_memory.py
+++ b/python/01-learn/18-self-improving-agents/code/step-04-ambient/create_memory.py
@@ -12,6 +12,10 @@ import boto3
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 NAME = os.environ.get("AIM308_MEMORY_NAME", "aim308_workshop_memory")
 
+# How long AgentCore retains raw events before expiry (in days). The
+# CreateMemory API requires this — omitting it raises ParamValidationError.
+EVENT_EXPIRY_DAYS = int(os.environ.get("AIM308_EVENT_EXPIRY_DAYS", "90"))
+
 
 def main():
     client = boto3.client("bedrock-agentcore-control", region_name=REGION)
@@ -20,7 +24,7 @@ def main():
     try:
         paginator = client.get_paginator("list_memories")
         for page in paginator.paginate():
-            for m in page.get("memorySummaries", []):
+            for m in page.get("memories", page.get("memorySummaries", [])):
                 if m.get("name") == NAME:
                     print(f"✅ Memory already exists: {m['id']}")
                     print(f"export BEDROCK_AGENTCORE_MEMORY_ID={m['id']}")
@@ -28,19 +32,30 @@ def main():
     except Exception as e:
         print(f"(list_memories failed: {e} - continuing to create)")
 
+    # Two built-in strategies, each writing to its OWN namespace:
+    #   - semanticMemoryStrategy      -> /users/{actorId}/facts
+    #   - userPreferenceMemoryStrategy -> /users/{actorId}/preferences
+    # The AgentCore API allows at most ONE namespace per strategy and ONE
+    # strategy of each type, so "facts" and "preferences" must be modeled as
+    # two different strategy types rather than two namespaces on one strategy.
+    # These namespaces match the agents' retrieval_config in agent.py.
     resp = client.create_memory(
         name=NAME,
         description="AIM308 NY Summit workshop - attendee long-term memory",
+        eventExpiryDuration=EVENT_EXPIRY_DAYS,
         memoryStrategies=[
             {
                 "semanticMemoryStrategy": {
-                    "name": "facts_and_preferences",
-                    "namespaces": [
-                        "/users/{actorId}/facts",
-                        "/users/{actorId}/preferences",
-                    ],
+                    "name": "facts",
+                    "namespaces": ["/users/{actorId}/facts"],
                 }
-            }
+            },
+            {
+                "userPreferenceMemoryStrategy": {
+                    "name": "preferences",
+                    "namespaces": ["/users/{actorId}/preferences"],
+                }
+            },
         ],
     )
     memory_id = resp["memory"]["id"]

--- a/python/01-learn/18-self-improving-agents/code/step-05-deploy/create_memory.py
+++ b/python/01-learn/18-self-improving-agents/code/step-05-deploy/create_memory.py
@@ -12,6 +12,10 @@ import boto3
 REGION = os.environ.get("AWS_REGION", "us-east-1")
 NAME = os.environ.get("AIM308_MEMORY_NAME", "aim308_workshop_memory")
 
+# How long AgentCore retains raw events before expiry (in days). The
+# CreateMemory API requires this — omitting it raises ParamValidationError.
+EVENT_EXPIRY_DAYS = int(os.environ.get("AIM308_EVENT_EXPIRY_DAYS", "90"))
+
 
 def main():
     client = boto3.client("bedrock-agentcore-control", region_name=REGION)
@@ -20,7 +24,7 @@ def main():
     try:
         paginator = client.get_paginator("list_memories")
         for page in paginator.paginate():
-            for m in page.get("memorySummaries", []):
+            for m in page.get("memories", page.get("memorySummaries", [])):
                 if m.get("name") == NAME:
                     print(f"✅ Memory already exists: {m['id']}")
                     print(f"export BEDROCK_AGENTCORE_MEMORY_ID={m['id']}")
@@ -28,19 +32,30 @@ def main():
     except Exception as e:
         print(f"(list_memories failed: {e} - continuing to create)")
 
+    # Two built-in strategies, each writing to its OWN namespace:
+    #   - semanticMemoryStrategy      -> /users/{actorId}/facts
+    #   - userPreferenceMemoryStrategy -> /users/{actorId}/preferences
+    # The AgentCore API allows at most ONE namespace per strategy and ONE
+    # strategy of each type, so "facts" and "preferences" must be modeled as
+    # two different strategy types rather than two namespaces on one strategy.
+    # These namespaces match the agents' retrieval_config in agent.py.
     resp = client.create_memory(
         name=NAME,
         description="AIM308 NY Summit workshop - attendee long-term memory",
+        eventExpiryDuration=EVENT_EXPIRY_DAYS,
         memoryStrategies=[
             {
                 "semanticMemoryStrategy": {
-                    "name": "facts_and_preferences",
-                    "namespaces": [
-                        "/users/{actorId}/facts",
-                        "/users/{actorId}/preferences",
-                    ],
+                    "name": "facts",
+                    "namespaces": ["/users/{actorId}/facts"],
                 }
-            }
+            },
+            {
+                "userPreferenceMemoryStrategy": {
+                    "name": "preferences",
+                    "namespaces": ["/users/{actorId}/preferences"],
+                }
+            },
         ],
     )
     memory_id = resp["memory"]["id"]

--- a/python/01-learn/18-self-improving-agents/code/step-05-deploy/deploy.sh
+++ b/python/01-learn/18-self-improving-agents/code/step-05-deploy/deploy.sh
@@ -12,6 +12,7 @@ PROJECT_NAME="${AIM308_PROJECT_NAME:-Aim308Deploy}"
 AGENT_NAME="${AIM308_AGENT_NAME:-aim308_research_agent}"
 REGION="${AWS_REGION:-us-east-1}"
 PROJECT_DIR="${AIM308_PROJECT_DIR:-./$PROJECT_NAME}"
+MODEL_ID="${BEDROCK_AGENTCORE_MODEL_ID:-global.anthropic.claude-opus-4-8}"
 
 # --- preflight checks -------------------------------------------------------
 
@@ -83,6 +84,8 @@ touch "$ENV_FILE"
 grep -q "^AWS_REGION=" "$ENV_FILE"                 || echo "AWS_REGION=$REGION" >> "$ENV_FILE"
 grep -q "^BEDROCK_AGENTCORE_MEMORY_ID=" "$ENV_FILE" || \
     echo "BEDROCK_AGENTCORE_MEMORY_ID=$BEDROCK_AGENTCORE_MEMORY_ID" >> "$ENV_FILE"
+grep -q "^BEDROCK_AGENTCORE_MODEL_ID=" "$ENV_FILE"  || \
+    echo "BEDROCK_AGENTCORE_MODEL_ID=$MODEL_ID" >> "$ENV_FILE"
 
 # --- step 4: install deps & deploy via CDK --------------------------------
 

--- a/python/01-learn/18-self-improving-agents/notebooks/00_hello_agent.ipynb
+++ b/python/01-learn/18-self-improving-agents/notebooks/00_hello_agent.ipynb
@@ -54,7 +54,7 @@
    "source": [
     "## Configure model + region\n",
     "\n",
-    "We use Claude Sonnet 4.5 on Amazon Bedrock in `us-east-1`. Make sure you have [model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) enabled."
+    "We use Claude Opus 4 (`global.anthropic.claude-opus-4-8`) on Amazon Bedrock in `us-east-1`. Make sure you have [model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access-modify.html) enabled."
    ]
   },
   {
@@ -67,7 +67,7 @@
     "import os\n",
     "import boto3\n",
     "ssm = boto3.client('ssm')\n",
-    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # Claude Sonnet 4.5\n",
+    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # model id from workshop SSM param\n",
     "REGION = ssm.get_parameter(Name='/aim308/region')['Parameter']['Value']\n",
     "os.environ[\"STRANDS_MODEL_ID\"] = MODEL_ID\n",
     "os.environ[\"AWS_REGION\"] = REGION\n",

--- a/python/01-learn/18-self-improving-agents/notebooks/01_self_extending.ipynb
+++ b/python/01-learn/18-self-improving-agents/notebooks/01_self_extending.ipynb
@@ -50,7 +50,7 @@
     "import os\n",
     "import boto3\n",
     "ssm = boto3.client('ssm')\n",
-    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # Claude Sonnet 4.5\n",
+    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # model id from workshop SSM param\n",
     "REGION = ssm.get_parameter(Name='/aim308/region')['Parameter']['Value']\n",
     "os.environ[\"AWS_REGION\"] = REGION\n",
     "os.environ[\"BYPASS_TOOL_CONSENT\"] = os.getenv(\"BYPASS_TOOL_CONSENT\", \"true\")\n",

--- a/python/01-learn/18-self-improving-agents/notebooks/02_self_modifying.ipynb
+++ b/python/01-learn/18-self-improving-agents/notebooks/02_self_modifying.ipynb
@@ -50,7 +50,7 @@
     "import os\n",
     "import boto3\n",
     "ssm = boto3.client('ssm')\n",
-    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # Claude Sonnet 4.5\n",
+    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # model id from workshop SSM param\n",
     "REGION = ssm.get_parameter(Name='/aim308/region')['Parameter']['Value']\n",
     "os.environ[\"AWS_REGION\"] = REGION\n",
     "os.environ[\"BYPASS_TOOL_CONSENT\"] = os.getenv(\"BYPASS_TOOL_CONSENT\", \"true\")\n",

--- a/python/01-learn/18-self-improving-agents/notebooks/03_memory.ipynb
+++ b/python/01-learn/18-self-improving-agents/notebooks/03_memory.ipynb
@@ -73,7 +73,7 @@
     "import os\n",
     "import boto3\n",
     "ssm = boto3.client('ssm')\n",
-    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # Claude Sonnet 4.5\n",
+    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # model id from workshop SSM param\n",
     "REGION = ssm.get_parameter(Name='/aim308/region')['Parameter']['Value']\n",
     "\n",
     "# If running outside workshop studio, run code/step-03-memory/create_memory.py first, then paste the ID here\n",

--- a/python/01-learn/18-self-improving-agents/notebooks/04_autonomous.ipynb
+++ b/python/01-learn/18-self-improving-agents/notebooks/04_autonomous.ipynb
@@ -50,7 +50,7 @@
     "import os\n",
     "import boto3\n",
     "ssm = boto3.client('ssm')\n",
-    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # Claude Sonnet 4.5\n",
+    "MODEL_ID = ssm.get_parameter(Name='/aim308/model-id')['Parameter']['Value']  # model id from workshop SSM param\n",
     "REGION = ssm.get_parameter(Name='/aim308/region')['Parameter']['Value']\n",
     "os.environ[\"AWS_REGION\"] = REGION\n",
     "# Ambient mode runs the agent on a background thread, which cannot answer the\n",


### PR DESCRIPTION
## Summary

Fixes the **Amazon Bedrock AgentCore Memory setup** for the `python/01-learn/18-self-improving-agents` workshop (AIM308), which is **currently broken against the live AgentCore `CreateMemory` API**. Every attendee hits a hard failure on **Step 3 (memory)** — which also blocks Steps 4 and 5 — because `create_memory.py` is missing a now-required parameter and uses a strategy/namespace shape the API no longer accepts. Also fixes a deploy-config gap and aligns the model label with the model the code actually uses.

### Workshop bug context (from end-to-end testing)

Steps 0, 1, 2, 4 work flawlessly. Step 3 fails at `create_memory.py`:

```
ParamValidationError: Missing required parameter in input: "eventExpiryDuration"
```

…and even after adding that, the API rejects the old single-`semanticMemoryStrategy` shape that packed two namespaces (`/facts` + `/preferences`) into one strategy — the current API caps **namespaces at 1 per strategy** and allows **one strategy per type**.

## What changed (7 files, surgical)

| Bug | Severity | Fix |
|---|---|---|
| **#1** `create_memory.py` missing required `eventExpiryDuration` | 🔴 blocker | Added `eventExpiryDuration=90` (env-overridable via `AIM308_EVENT_EXPIRY_DAYS`) to all **3** `create_memory.py` copies (steps 03/04/05). |
| **#2** strategy/namespace shape rejected | 🔴 blocker | Modeled facts + preferences as **two strategy types** — `semanticMemoryStrategy` (`/users/{actorId}/facts`) + `userPreferenceMemoryStrategy` (`/users/{actorId}/preferences`) — each with a **single** namespace. Satisfies the API's *1-namespace-per-strategy / 1-strategy-per-type* limits **while keeping both namespaces**, so no `agent.py` changes are needed. This matches the canonical pattern in the AgentCore SDK's own Strands integration README. |
| **#2-followup** `list_memories` paginator key | 🔴 | Fixed the result key from `memorySummaries` → `memories` (matches the botocore paginator config). Kept a `.get(..., .get(...))` fallback for backward compatibility. |
| **#3** `deploy.sh` never injected the model ID | 🟡 | `deploy.sh` now writes `BEDROCK_AGENTCORE_MODEL_ID` into `.env.local` (default `global.anthropic.claude-opus-4-8`); the deployed Step-5 runtime previously got `MODEL_ID=None`. |
| **#4** README / notebook model-label mismatch | 🟢 | Aligned labels to **Claude Opus 4 (`global.anthropic.claude-opus-4-8`)** — the model every `agent.py` actually hardcodes — across the main README, step-00 README, `step-00-hello/agent.py` docstring, and notebooks 00/01/02/03/04. (Old labels said "Claude Sonnet 4.5" / "Claude 4.6 Sonnet".) |

## Review Loop Summary

This PR went through **3 pre-PR review iterations** (fresh-context reviewer chain, `task-pr-gate` Mode A) before being opened:

| Iteration | Actor | Run | Findings Addressed |
|-----------|-------|-----|--------------------|
| 1 | implementor | [27666225904](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/27666225904) | Built the core fix: `eventExpiryDuration` + two-strategy model (semantic facts + userPreference preferences) keeping BOTH namespaces; `list_memories` key fix; `deploy.sh` model-id injection; initial README/notebook label cleanup. Validated via `py_compile`, `bash -n`, and botocore `ParamValidator` (new params PASS, old params REJECTED with the exact `eventExpiryDuration` error). |
| 2 | reviewer | [27666645205](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/27666645205) | Re-derived the core fix **cold** and CONFIRMED it (botocore model + SDK README + `ParamValidator`). Found & fixed 1 gap: model-label cleanup was incomplete — `Sonnet 4.5/4.6` labels still in notebooks 00/01/02/04 + `step-00-hello/agent.py` docstring while every `agent.py` hardcodes `claude-opus-4-8`. Aligned all to Opus 4. |
| 3 | reviewer (this run) | [27666957859](https://github.com/agent-of-mkmeral/strands-coder-private/actions/runs/27666957859) | Re-derived everything cold one final time at the iteration cap; **all checks pass, no new regression**. Opened this PR. |

## Test Plan

All validation done at the schema + SDK-doc level (live AgentCore create blocked in CI — see caveat). Re-run cold in iteration 3:

**botocore `ParamValidator` against the live `CreateMemory` input shape:**
```
=== CreateMemory required members ===
required: ['name', 'eventExpiryDuration']
=== memoryStrategy union members ===
['semanticMemoryStrategy', 'summaryMemoryStrategy', 'userPreferenceMemoryStrategy', 'customMemoryStrategy', 'episodicMemoryStrategy']
=== NEW params validation ===  -> NONE (PASS)
=== OLD params validation ===  -> Missing required parameter in input: "eventExpiryDuration"
```
→ Proves `eventExpiryDuration` is genuinely required, the branch's new params pass, and the old params fail with the exact error attendees hit. Both `semanticMemoryStrategy` and `userPreferenceMemoryStrategy` are valid sibling union members.

**SDK README cross-check** (`bedrock_agentcore/memory/integrations/strands/README.md`): documents all three built-in strategies (`summaryMemoryStrategy`, `userPreferenceMemoryStrategy`, `semanticMemoryStrategy`) coexisting in one `create_memory` — confirming the two-strategy pattern is canonical.

**`list_memories` paginator** result key is `memories` (matches the fix).

**Namespace consistency:** `retrieval_config` in all three `agent.py` (steps 03/04/05) **and** notebook 03 references **both** `/users/{actorId}/facts` and `/users/{actorId}/preferences`, exactly matching the two namespaces `create_memory.py` creates.

**Structural checks:**
```
md5sum (3× create_memory.py)  -> all identical (b0d27fd7f9817a77daf7cd2babec1965)
py_compile (all .py)          -> OK
bash -n deploy.sh             -> OK
JSON-validate (all notebooks) -> OK
grep Sonnet|4.5|4.6 (code/md/ipynb) -> 0 matches
grep facts_and_preferences (old shape) -> 0 matches
model_id across all agent.py  -> consistent global.anthropic.claude-opus-4-8
```

## ⚠️ Caveat — NOT live-validated in CI

**This fix has NOT been live-validated against AgentCore in this environment.** The CI role (`StrandsActionRole`) gets a blanket `ForbiddenException` on all `bedrock-agentcore-control` operations, so a memory could not be created here. The fix is validated at the **schema + SDK-documentation level only**.

👉 **Before the workshop, someone should run `create_memory.py` once with real AgentCore access** to confirm the memory goes `ACTIVE` end-to-end. (An earlier manual e2e run in a different environment did confirm store+recall works once the memory exists.)

## Remaining Findings (filed as inline review comments)

- 🟢 The rendered assets in `images/*.svg` and `casts/*.svg`/`.cast` still display "Claude 4.6 Sonnet". These are pre-generated/recorded artifacts (not editable source), low priority — flagged for a future regen, not blocking.
