### PR TITLE
docs(samples): add DaoXE OpenAI-compatible model provider sample

### DIFF
--- a/python/01-learn/03-model-providers/04-daoxe-model/README.md
+++ b/python/01-learn/03-model-providers/04-daoxe-model/README.md
@@ -1,0 +1,77 @@
+# DaoXE OpenAI-compatible provider with Strands Agents
+
+Use [DaoXE](https://daoxe.com) as an OpenAI-compatible multi-model gateway from Strands Agents via `strands.models.openai.OpenAIModel`.
+
+DaoXE exposes Chat Completions at `https://daoxe.com/v1`. Model IDs are **account-scoped** (use your dashboard catalog or `GET /v1/models`). DaoXE is multi-protocol (OpenAI-compatible + Anthropic Messages where available); this sample covers the OpenAI path for Strands.
+
+> **Availability:** DaoXE is **not available in mainland China**.
+
+## Tutorial Details
+
+| Information | Details |
+|-------------|---------|
+| **Strands Features** | OpenAI-compatible model provider (`OpenAIModel`) |
+| **Agent Pattern** | Single agent |
+| **Tools** | Custom tools (`current_time`, `current_weather`) |
+| **Model** | Account-scoped model ID on DaoXE (`https://daoxe.com/v1`) |
+
+## Key Concepts
+
+- **OpenAI compatibility**: Point Strands `OpenAIModel` at DaoXE with `base_url=https://daoxe.com/v1`.
+- **Account-scoped model IDs**: Do not hardcode a public model list; use your DaoXE account catalog.
+- **Multi-protocol gateway**: Same gateway also supports other protocol surfaces for non-Strands clients; this sample uses OpenAI Chat Completions only.
+
+## Prerequisites
+
+- Python 3.10+
+- DaoXE account and API key from [daoxe.com](https://daoxe.com)
+- A model ID enabled on your DaoXE account
+- Network access from a region where DaoXE is available (not mainland China)
+
+## Getting Started
+
+1. **Install dependencies:**
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. **Set environment variables:**
+
+   ```bash
+   export DAOXE_API_KEY="your-daoxe-api-key"
+   export DAOXE_MODEL_ID="your-account-model-id"
+   ```
+
+3. **Run the CLI sample:**
+
+   ```bash
+   python daoxe_openai_agent.py
+   ```
+
+4. **Or open the notebook:**
+
+   ```bash
+   jupyter notebook daoxe-openai-agent.ipynb
+   ```
+
+## Project Structure
+
+```
+04-daoxe-model/
+├── daoxe_openai_agent.py      # CLI script
+├── daoxe-openai-agent.ipynb   # Interactive notebook
+├── requirements.txt
+├── README.md
+```
+
+## Affiliation
+
+Community contribution from a DaoXE maintainer (`seven7763`). Examples: https://github.com/seven7763/DaoXE-AI
+
+## References
+
+- [DaoXE](https://daoxe.com)
+- [DaoXE-AI client examples](https://github.com/seven7763/DaoXE-AI)
+- [Strands community: DaoXE model provider](https://strandsagents.com/) (community model providers catalog)
+- [OpenAI Python SDK](https://github.com/openai/openai-python)

--- a/python/01-learn/03-model-providers/04-daoxe-model/daoxe-openai-agent.ipynb
+++ b/python/01-learn/03-model-providers/04-daoxe-model/daoxe-openai-agent.ipynb
@@ -1,0 +1,251 @@
+{
+ "nbformat": 4,
+ "nbformat_minor": 5,
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using DaoXE (OpenAI-compatible) with Strands Agents\n",
+    "\n",
+    "## Overview\n",
+    "\n",
+    "[DaoXE](https://daoxe.com) is a multi-model multi-protocol AI API gateway. It exposes an OpenAI-compatible Chat Completions endpoint at `https://daoxe.com/v1`, so Strands can use the built-in `OpenAIModel` provider without a custom package.\n",
+    "\n",
+    "This notebook builds a small agent with two demo tools (`current_time`, `current_weather`) routed through DaoXE.\n",
+    "\n",
+    "> **Notes**\n",
+    "> - Model IDs are **account-scoped** \u2014 use your DaoXE dashboard or `GET https://daoxe.com/v1/models`.\n",
+    "> - DaoXE also supports other protocol surfaces (e.g. Anthropic Messages) for clients that speak those APIs natively; this sample covers the **OpenAI-compatible** path only.\n",
+    "> - DaoXE is **not available in mainland China**.\n",
+    "\n",
+    "## Agent Details\n",
+    "\n",
+    "| Feature | Description |\n",
+    "|---------|-------------|\n",
+    "| Feature used | OpenAI-compatible model provider (`OpenAIModel`) |\n",
+    "| Agent structure | Single agent |\n",
+    "| Gateway | `https://daoxe.com/v1` |\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Setup and prerequisites\n",
+    "\n",
+    "### Prerequisites\n",
+    "* Python 3.10+\n",
+    "* DaoXE API key from [daoxe.com](https://daoxe.com)\n",
+    "* Account-scoped model ID enabled for your key\n",
+    "* Network access outside mainland China\n",
+    "\n",
+    "Install packages:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -r requirements.txt\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Import dependencies\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from datetime import datetime\n",
+    "from datetime import timezone as tz\n",
+    "from typing import Any\n",
+    "from zoneinfo import ZoneInfo\n",
+    "\n",
+    "from strands import Agent, tool\n",
+    "from strands.models.openai import OpenAIModel\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure DaoXE credentials\n",
+    "\n",
+    "Set `DAOXE_API_KEY` and `DAOXE_MODEL_ID` in your environment (preferred), or assign them in the next cell for a local notebook session.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prefer environment variables in real use:\n",
+    "# export DAOXE_API_KEY=\"your-daoxe-api-key\"\n",
+    "# export DAOXE_MODEL_ID=\"your-account-model-id\"\n",
+    "\n",
+    "api_key = os.environ.get(\"DAOXE_API_KEY\", \"\")\n",
+    "model_id = os.environ.get(\"DAOXE_MODEL_ID\", \"\")\n",
+    "\n",
+    "if not api_key or not model_id:\n",
+    "    raise ValueError(\n",
+    "        \"Set DAOXE_API_KEY and DAOXE_MODEL_ID. Model IDs are account-scoped \"\n",
+    "        \"(dashboard or GET https://daoxe.com/v1/models). DaoXE is not available in mainland China.\"\n",
+    "    )\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define demo tools\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@tool\n",
+    "def current_time(timezone: str = \"UTC\") -> str:\n",
+    "    if timezone.upper() == \"UTC\":\n",
+    "        timezone_obj: Any = tz.utc\n",
+    "    else:\n",
+    "        timezone_obj = ZoneInfo(timezone)\n",
+    "    return datetime.now(timezone_obj).isoformat()\n",
+    "\n",
+    "\n",
+    "@tool\n",
+    "def current_weather(city: str) -> str:\n",
+    "    # Dummy implementation. Replace with a real weather API if needed.\n",
+    "    return f\"sunny in {city}\" \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create OpenAIModel pointed at DaoXE\n",
+    "\n",
+    "`base_url` must be exactly `https://daoxe.com/v1` (include `/v1`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = OpenAIModel(\n",
+    "    client_args={\n",
+    "        \"api_key\": api_key,\n",
+    "        \"base_url\": \"https://daoxe.com/v1\",\n",
+    "    },\n",
+    "    # Account-scoped model ID from your DaoXE catalog \u2014 not a fixed public list\n",
+    "    model_id=model_id,\n",
+    "    params={\n",
+    "        \"max_tokens\": 2048,\n",
+    "        \"temperature\": 0.2,\n",
+    "    },\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build the agent\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "system_prompt = \"You are a simple agent that can tell the time and the weather\"\n",
+    "agent = Agent(\n",
+    "    model=model,\n",
+    "    system_prompt=system_prompt,\n",
+    "    tools=[current_time, current_weather],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke the agent\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = agent(\"What time is it in Seattle? And how is the weather?\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Inspect conversation and metrics\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent.messages\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results.metrics\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Multi-protocol note\n",
+    "\n",
+    "This sample uses DaoXE's **OpenAI-compatible** surface. For Anthropic Messages (or other) protocol paths, use the matching client/SDK against the endpoint documented in your DaoXE console. Client setup samples: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI).\n",
+    "\n",
+    "## Affiliation\n",
+    "\n",
+    "Community contribution from a DaoXE maintainer (`seven7763`).\n"
+   ]
+  }
+ ]
+}

--- a/python/01-learn/03-model-providers/04-daoxe-model/daoxe_openai_agent.py
+++ b/python/01-learn/03-model-providers/04-daoxe-model/daoxe_openai_agent.py
@@ -1,0 +1,70 @@
+"""Strands agent using DaoXE via the OpenAI-compatible provider.
+
+DaoXE base URL: https://daoxe.com/v1
+Model IDs are account-scoped. DaoXE is multi-protocol; this sample uses OpenAI Chat Completions.
+Not available in mainland China.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from datetime import timezone as tz
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from strands import Agent, tool
+from strands.models.openai import OpenAIModel
+
+
+@tool
+def current_time(timezone: str = "UTC") -> str:
+    """Return the current time in ISO format for the given timezone."""
+    if timezone.upper() == "UTC":
+        timezone_obj: Any = tz.utc
+    else:
+        timezone_obj = ZoneInfo(timezone)
+    return datetime.now(timezone_obj).isoformat()
+
+
+@tool
+def current_weather(city: str) -> str:
+    """Return a dummy weather string for the given city (replace with a real API if needed)."""
+    return f"sunny in {city}"
+
+
+def main() -> None:
+    api_key = os.environ.get("DAOXE_API_KEY")
+    model_id = os.environ.get("DAOXE_MODEL_ID")
+    if not api_key:
+        raise SystemExit("Set DAOXE_API_KEY to your DaoXE API key.")
+    if not model_id:
+        raise SystemExit(
+            "Set DAOXE_MODEL_ID to an account-scoped model ID from your DaoXE catalog "
+            "(dashboard or GET https://daoxe.com/v1/models)."
+        )
+
+    model = OpenAIModel(
+        client_args={
+            "api_key": api_key,
+            "base_url": "https://daoxe.com/v1",
+        },
+        model_id=model_id,
+        params={
+            "max_tokens": 2048,
+            "temperature": 0.2,
+        },
+    )
+
+    agent = Agent(
+        model=model,
+        system_prompt="You are a simple agent that can tell the time and the weather.",
+        tools=[current_time, current_weather],
+    )
+
+    result = agent("What time is it in Seattle? And how is the weather?")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/01-learn/03-model-providers/04-daoxe-model/requirements.txt
+++ b/python/01-learn/03-model-providers/04-daoxe-model/requirements.txt
@@ -1,0 +1,2 @@
+strands-agents[openai]
+strands-agents-tools

--- a/python/01-learn/03-model-providers/README.md
+++ b/python/01-learn/03-model-providers/README.md
@@ -1,14 +1,14 @@
 # Model Providers in Strands Agents
 
-Strands Agents takes a model-driven approach and is not tied to a single model or vendor. A *model provider* is the adapter that connects your agent to a specific model, and the SDK ships with providers for Amazon Bedrock, Anthropic, Ollama, LiteLLM, OpenAI, and more. This tutorial shows three of them in practice: running a model locally with Ollama, reaching Azure OpenAI through LiteLLM, and calling OpenAI models hosted on Amazon Bedrock through the Responses API.
+Strands Agents takes a model-driven approach and is not tied to a single model or vendor. A *model provider* is the adapter that connects your agent to a specific model, and the SDK ships with providers for Amazon Bedrock, Anthropic, Ollama, LiteLLM, OpenAI, and more. This tutorial shows several of them in practice: running a model locally with Ollama, reaching Azure OpenAI through LiteLLM, calling OpenAI models hosted on Amazon Bedrock through the Responses API, and pointing Strands `OpenAIModel` at an OpenAI-compatible multi-model gateway (DaoXE).
 
 ## Tutorial Details
 
 | Information          | Details                                                                 |
 |----------------------|-------------------------------------------------------------------------|
 | **Agent structure**  | Single agent                                                            |
-| **Strands model providers** | `OllamaModel`, `LiteLLMModel`, `OpenAIResponsesModel`             |
-| **Where they run**          | Your local machine (Ollama), Azure OpenAI (via LiteLLM), Amazon Bedrock |
+| **Strands model providers** | `OllamaModel`, `LiteLLMModel`, `OpenAIResponsesModel`, `OpenAIModel` |
+| **Where they run**          | Your local machine (Ollama), Azure OpenAI (via LiteLLM), Amazon Bedrock, OpenAI-compatible gateways |
 | **Strands features** | Swapping model providers, passing a configured model to `Agent`         |
 
 ## Key Concepts
@@ -35,7 +35,7 @@ This is not the full list. See the [model providers documentation](https://stran
 
 - Python 3.10 or higher
 - Basic understanding of Python
-- Provider-specific requirements, called out in each sub-sample (Ollama installed locally, an Azure OpenAI deployment, or an AWS account with access to OpenAI models on Amazon Bedrock)
+- Provider-specific requirements, called out in each sub-sample (Ollama installed locally, an Azure OpenAI deployment, an AWS account with access to OpenAI models on Amazon Bedrock, or an OpenAI-compatible gateway API key)
 
 ## Tutorial Structure
 
@@ -46,16 +46,17 @@ Each sub-sample is self-contained and has its own `requirements.txt`.
 | [01-ollama-model/ollama-file-ops-agent.ipynb](./01-ollama-model/ollama-file-ops-agent.ipynb) | Run a model locally with `OllamaModel` and build a file-operations agent (`file_read`, `file_write`, `list_directory`). |
 | [02-openai-litellm/openai-litellm-agent.ipynb](./02-openai-litellm/openai-litellm-agent.ipynb) | Reach an Azure OpenAI model through `LiteLLMModel` and give the agent `current_time` and `current_weather` tools. |
 | [03-openai-responses-on-bedrock/openai-responses-agent.ipynb](./03-openai-responses-on-bedrock/openai-responses-agent.ipynb) | Call an OpenAI model hosted on Amazon Bedrock with `OpenAIResponsesModel` and the Responses API. |
+| [04-daoxe-model/daoxe-openai-agent.ipynb](./04-daoxe-model/daoxe-openai-agent.ipynb) | Point Strands `OpenAIModel` at the [DaoXE](https://daoxe.com) OpenAI-compatible multi-model gateway (`base_url=https://daoxe.com/v1`). Model IDs are account-scoped. Not available in mainland China. |
 
 ## Getting Started
 
 1. **Install dependencies** for the sub-sample you want to run:
    ```bash
-   cd 01-ollama-model        # or: 02-openai-litellm, 03-openai-responses-on-bedrock
+   cd 01-ollama-model        # or: 02-openai-litellm, 03-openai-responses-on-bedrock, 04-daoxe-model
    pip install -r requirements.txt
    ```
 
-2. **Run the notebook** in that folder and run the cells in order.
+2. **Run the notebook** in that folder and run the cells in order. The DaoXE sample also has a CLI script (`daoxe_openai_agent.py`).
 
 ## Project Structure
 
@@ -74,10 +75,14 @@ Each sub-sample is self-contained and has its own `requirements.txt`.
 │   ├── openai-responses-agent.ipynb
 │   ├── requirements.txt
 │   └── images/
+├── 04-daoxe-model/
+│   ├── daoxe-openai-agent.ipynb
+│   ├── daoxe_openai_agent.py
+│   ├── requirements.txt
+│   └── README.md
 └── README.md
 ```
 
 ## Cleanup
 
-The Ollama notebook writes local files (for example `sample.txt` and `readme.md`) in its folder when you run the examples; delete them to reset. The LiteLLM and Responses notebooks call hosted model APIs only and create no persistent resources.
-
+The Ollama notebook writes local files (for example `sample.txt` and `readme.md`) in its folder when you run the examples; delete them to reset. The LiteLLM, Responses, and DaoXE notebooks call hosted model APIs only and create no persistent resources.


### PR DESCRIPTION
## Summary
Adds a model-providers tutorial for **DaoXE** under `python/01-learn/03-model-providers/04-daoxe-model/`, following the existing OpenAI/LiteLLM sample style.

- Base URL: `https://daoxe.com/v1`
- Uses built-in `strands.models.openai.OpenAIModel` (no separate package)
- Account-scoped model IDs only (`DAOXE_MODEL_ID` / dashboard / `GET /v1/models`)
- Notes multi-protocol surface (OpenAI-compatible + Anthropic Messages where available); this sample covers the OpenAI path for Strands
- Notes service is **not available in mainland China**
- CLI script + notebook + README; parent model-providers README updated
- Discloses maintainer affiliation (`seven7763`)

Related docs PR on the monorepo: https://github.com/strands-agents/harness-sdk/pull/3218  
(`strands-agents/sdk-python` redirects to `harness-sdk`; this samples PR is the complementary runnable example.)

## Why
Strands already documents OpenAI-compatible gateways. DaoXE is a multi-model multi-protocol gateway users can point at with `base_url=https://daoxe.com/v1`.

## Test plan
- [ ] Files appear under `python/01-learn/03-model-providers/04-daoxe-model/`
- [ ] `requirements.txt` installs `strands-agents[openai]` + tools
- [ ] CLI uses `OpenAIModel(client_args={api_key, base_url}, model_id=...)`
- [ ] Optional: smoke with real `DAOXE_API_KEY` + account model id
- [ ] Parent README lists the new sample

I maintain DaoXE. Examples: https://github.com/seven7763/DaoXE-AI