### PR TITLE
fix: pass agents directly as tools in the agents-as-tools lab

### DIFF
--- a/python/01-learn/10-agents-as-tools/agent-as-tools.ipynb
+++ b/python/01-learn/10-agents-as-tools/agent-as-tools.ipynb
@@ -73,7 +73,7 @@
    "source": [
     "import os\n",
     "\n",
-    "from strands import Agent, tool\n",
+    "from strands import Agent\n",
     "from strands_tools import file_write\n"
    ]
   },
@@ -120,6 +120,8 @@
    "outputs": [],
    "source": [
     "research_agent = Agent(\n",
+    "    name=\"research_assistant\",\n",
+    "    description=\"Answers research questions with factual, well-sourced information.\",\n",
     "    model=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",\n",
     "    system_prompt=RESEARCH_ASSISTANT_PROMPT,\n",
     "    # tools=[http_request]  # Here you can enable an agentic ai search tool\n",
@@ -134,15 +136,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can wrap this agent as a tool. Allowing other agents to interact with it. \n",
+    "This same agent can now be handed to another agent as a tool. Pass the `Agent` straight into another agent's `tools` list, and the SDK converts it using the agent's `name` and `description`.\n",
+    "\n",
+    "Call `agent.as_tool()` yourself when you want to override either of those.\n",
     "\n",
     "####  Best Practices for Agent as Tools\n",
     "\n",
     "When implementing the \"Agents as Tools\" pattern with Strands Agents:\n",
     "\n",
-    "1. Clear tool documentation: Write descriptive docstrings that explain the agent's expertise\n",
+    "1. Clear tool descriptions: Give each agent a `description` explaining its expertise, since that is what the orchestrator sees when choosing a tool\n",
     "2. Focused system prompts: Keep each specialized agent tightly focused on its domain\n",
-    "3. Proper response handling: Use consistent patterns to extract and format responses\n",
+    "3. Meaningful agent names: The agent's `name` becomes the tool name, so it should match how the orchestrator's prompt refers to it\n",
     "4. Tool selection guidance: Give the orchestrator clear criteria for when to use each specialized agent"
    ]
   },
@@ -152,36 +156,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@tool\n",
-    "def research_assistant(query: str) -> str:\n",
-    "    \"\"\"\n",
-    "    Process and respond to research-related queries.\n",
+    "# Passing `research_agent` directly is the same as passing `research_agent.as_tool()`.\n",
+    "# Call `as_tool()` yourself only when you want to override the generated name or description.\n",
+    "research_tool = research_agent.as_tool(\n",
+    "    description=\"Use for research questions that need factual, well-sourced answers.\"\n",
+    ")\n",
     "\n",
-    "    Args:\n",
-    "        query: A research question requiring factual information\n",
-    "\n",
-    "    Returns:\n",
-    "        A detailed research answer with citations\n",
-    "    \"\"\"\n",
-    "    try:\n",
-    "        # Strands agents makes it easy to create a specialized agent\n",
-    "        research_agent = Agent(\n",
-    "            model=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",\n",
-    "            system_prompt=RESEARCH_ASSISTANT_PROMPT,\n",
-    "        )\n",
-    "\n",
-    "        # Call the agent and return its response\n",
-    "        response = research_agent(query)\n",
-    "        return str(response)\n",
-    "    except Exception as e:\n",
-    "        return f\"Error in research assistant: {str(e)}\""
+    "print(\"Tool name:\", research_tool.tool_name)\n",
+    "print(\"Tool description:\", research_tool.tool_spec[\"description\"])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now lets follow the best practices and create `product_recommendation_assistant`, `trip_planning_assistant`, and `orchestrator` agent."
+    "Now lets follow the best practices and create the `product_recommendation_assistant` and `trip_planning_assistant` agents, followed by the `orchestrator` that routes between them."
    ]
   },
   {
@@ -197,29 +186,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@tool\n",
-    "def product_recommendation_assistant(query: str) -> str:\n",
-    "    \"\"\"\n",
-    "    Handle product recommendation queries by suggesting appropriate products.\n",
-    "\n",
-    "    Args:\n",
-    "        query: A product inquiry with user preferences\n",
-    "\n",
-    "    Returns:\n",
-    "        Personalized product recommendations with reasoning\n",
-    "    \"\"\"\n",
-    "    try:\n",
-    "        product_agent = Agent(\n",
-    "            model=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",  # Optional: Specify the model ID\n",
-    "            system_prompt=\"\"\"You are a specialized product recommendation assistant.\n",
-    "            Provide personalized product suggestions based on user preferences. Always cite your sources.\"\"\",\n",
-    "        )\n",
-    "        # Call the agent and return its response\n",
-    "        response = product_agent(query)\n",
-    "\n",
-    "        return str(response)\n",
-    "    except Exception as e:\n",
-    "        return f\"Error in product recommendation: {str(e)}\""
+    "product_agent = Agent(\n",
+    "    name=\"product_recommendation_assistant\",\n",
+    "    description=\"Suggests products based on user preferences, with reasoning and sources.\",\n",
+    "    model=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",  # Optional: Specify the model ID\n",
+    "    system_prompt=\"\"\"You are a specialized product recommendation assistant.\n",
+    "    Provide personalized product suggestions based on user preferences. Always cite your sources.\"\"\",\n",
+    ")"
    ]
   },
   {
@@ -228,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "product_recommendation_assistant(\"Product recommendations for flying cars\")"
+    "product_agent(\"Product recommendations for flying cars\")"
    ]
   },
   {
@@ -244,29 +217,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@tool\n",
-    "def trip_planning_assistant(query: str) -> str:\n",
-    "    \"\"\"\n",
-    "    Create travel itineraries and provide travel advice.\n",
-    "\n",
-    "    Args:\n",
-    "        query: A travel planning request with destination and preferences\n",
-    "\n",
-    "    Returns:\n",
-    "        A detailed travel itinerary or travel advice\n",
-    "    \"\"\"\n",
-    "    try:\n",
-    "        travel_agent = Agent(\n",
-    "            model=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",  # Optional: Specify the model ID\n",
-    "            system_prompt=\"\"\"You are a specialized travel planning assistant.\n",
-    "            Create detailed travel itineraries based on user preferences.\"\"\",\n",
-    "        )\n",
-    "        # Call the agent and return its response\n",
-    "        response = travel_agent(query)\n",
-    "\n",
-    "        return str(response)\n",
-    "    except Exception as e:\n",
-    "        return f\"Error in trip planning: {str(e)}\""
+    "travel_agent = Agent(\n",
+    "    name=\"trip_planning_assistant\",\n",
+    "    description=\"Creates travel itineraries and gives travel advice.\",\n",
+    "    model=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",  # Optional: Specify the model ID\n",
+    "    system_prompt=\"\"\"You are a specialized travel planning assistant.\n",
+    "    Create detailed travel itineraries based on user preferences.\"\"\",\n",
+    ")"
    ]
   },
   {
@@ -300,14 +257,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Strands Agents allows easy integration of agent tools\n",
+    "# Strands Agents converts each Agent into a tool automatically\n",
     "orchestrator = Agent(\n",
     "    model=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",  # Optional: Specify the model ID\n",
     "    system_prompt=MAIN_SYSTEM_PROMPT,\n",
     "    tools=[\n",
-    "        research_assistant,\n",
-    "        product_recommendation_assistant,\n",
-    "        trip_planning_assistant,\n",
+    "        research_agent,\n",
+    "        product_agent,\n",
+    "        travel_agent,\n",
     "        file_write,\n",
     "    ],\n",
     ")"


### PR DESCRIPTION

*Description of changes:*
## Problem

`python/01-learn/10-agents-as-tools/agent-as-tools.ipynb` wraps every specialist in a `@tool` function that constructs a fresh `Agent` internally, calls it, and returns`str(response)`. The same block is repeated three times.

Strands accepts an `Agent` directly in `tools=[]` and converts it using the agent's`name` and `description`, so the wrappers are unnecessary.

## Fix
Give each specialist a `name` and `description`, and pass it to the orchestrator directly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
