### PR TITLE
Rewrite the AgentCore tutorial on the AgentCore CLI

### DIFF
--- a/python/02-deploy/03-agentcore/deploy-agent.ipynb
+++ b/python/02-deploy/03-agentcore/deploy-agent.ipynb
@@ -61,9 +61,9 @@
    "source": [
     "### Install the AgentCore CLI\n",
     "\n",
-    "The [AgentCore CLI](https://github.com/aws/agentcore-cli) is a command line tool that creates an agent project, packages the code as a zip archive, and deploys it to Amazon Bedrock AgentCore Runtime through AWS CloudFormation. It needs Node.js 20 or later to run and `uv` (installed above) to resolve the agent's Python dependencies for the arm64 runtime. Confirm both are available.\n",
+    "The [AgentCore CLI](https://github.com/aws/agentcore-cli) is a command line tool for creating, developing, and deploying agents on Amazon Bedrock AgentCore. It scaffolds an agent project, runs the agent locally for development, deploys it to AgentCore Runtime, and manages the deployed resources.\n",
     "\n",
-    "Cells that start with `%%bash` run their contents as a shell script. Unlike a `!` command, a `%%bash` cell raises an error when the script exits with a non-zero status, so a failed CLI command stops the notebook instead of scrolling past.\n"
+    "It runs on Node.js and uses `uv` to resolve an agent's Python dependencies for the arm64 architecture that AgentCore Runtime requires."
    ]
   },
   {
@@ -83,7 +83,7 @@
    "id": "298364de-ad6b-4cbb-b360-7fa05f19d52a",
    "metadata": {},
    "source": [
-    "Install the AgentCore CLI globally with npm. This is the same command the AWS Developer Guide uses."
+    "Install the AgentCore CLI globally with npm."
    ]
   },
   {
@@ -130,31 +130,7 @@
    "id": "9be06b4f-973a-4c3e-a5ee-4dfb70715525",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import boto3, json, time, uuid, os, re\n",
-    "from utils import (\n",
-    "    create_execution_role,\n",
-    "    delete_execution_role,\n",
-    "    get_runtime_arn,\n",
-    "    assert_runtimes_absent,\n",
-    "    assert_stack_absent,\n",
-    ")\n",
-    "\n",
-    "session = boto3.Session()\n",
-    "region = session.region_name or \"us-east-1\"\n",
-    "account_id = boto3.client(\"sts\").get_caller_identity()[\"Account\"]\n",
-    "print(f\"Region: {region} | Account: {account_id}\")\n",
-    "\n",
-    "# Data plane client used to invoke deployed agents\n",
-    "agentcore_client = boto3.client(\"bedrock-agentcore\", region_name=region)\n",
-    "\n",
-    "# One CLI project holds both agents in this tutorial. Project names must be alphanumeric.\n",
-    "# The CLI commands below use the same names as literals, so they can be copied into a terminal.\n",
-    "PROJECT_NAME = \"agentcorelab\"\n",
-    "hello_agent_name = \"hello_agent\"\n",
-    "prod_agent_name = \"strands_restaurant_agent\"\n",
-    "PYTHON_RUNTIME = \"PYTHON_3_13\""
-   ]
+   "source": "import boto3, json, time, uuid, os, re\nfrom utils import (\n    create_execution_role,\n    delete_execution_role,\n    assert_runtimes_absent,\n    assert_stack_absent,\n)\n\nsession = boto3.Session()\nregion = session.region_name or \"us-east-1\"\naccount_id = boto3.client(\"sts\").get_caller_identity()[\"Account\"]\nprint(f\"Region: {region} | Account: {account_id}\")\n\n# Data plane client used to invoke deployed agents\nagentcore_client = boto3.client(\"bedrock-agentcore\", region_name=region)\n\n# One CLI project holds both agents in this tutorial. Project names must be alphanumeric.\n# The CLI commands below use the same names as literals, so they can be copied into a terminal.\nPROJECT_NAME = \"agentcorelab\"\nhello_agent_name = \"hello_agent\"\nprod_agent_name = \"strands_restaurant_agent\"\nPYTHON_RUNTIME = \"PYTHON_3_13\""
   },
   {
    "cell_type": "markdown",
@@ -163,13 +139,11 @@
    "source": [
     "## Step 1: Deploy a Hello Agent\n",
     "\n",
-    "Start by deploying a minimal agent that demonstrates the basic deployment workflow: create a project, deploy, invoke, and remove.\n",
+    "Start by deploying a minimal agent: create a project, deploy it, invoke it, and remove it.\n",
     "\n",
-    "### Create a project with the AgentCore CLI\n",
+    "### Create a project\n",
     "\n",
-    "The AgentCore CLI works on a project: a directory with an `agentcore/agentcore.json` configuration file that lists the agents to deploy, plus an `app/` directory holding each agent's code. The `create` command scaffolds all of it.\n",
-    "\n",
-    "The commands in this tutorial are the same ones you would run in a terminal. Project names must be alphanumeric, and agent names allow underscores."
+    "An AgentCore CLI project is a directory holding an `agentcore/agentcore.json` configuration file that lists the agents to deploy, and an `app/` directory containing each agent's code. The `create` command scaffolds both. Project names must be alphanumeric, and agent names may also contain underscores."
    ]
   },
   {
@@ -197,8 +171,8 @@
     "This command:\n",
     "\n",
     "- Creates the `agentcorelab/` project directory\n",
-    "- Writes `agentcore/agentcore.json`, which declares one agent named `hello_agent` with `build: CodeZip`, an entrypoint of `main.py`, and the Python runtime version\n",
-    "- Generates a starter agent under `app/hello_agent/` with a `pyproject.toml` that lists its dependencies\n",
+    "- Writes `agentcore/agentcore.json`, declaring one agent named `hello_agent` with `build: CodeZip`, an entrypoint of `main.py`, and the Python runtime version\n",
+    "- Generates a starter agent under `app/hello_agent/` with a `pyproject.toml` listing its dependencies\n",
     "- Runs `uv sync` to create a local virtual environment for the agent\n",
     "\n",
     "Inspect the project layout and the configuration file."
@@ -222,13 +196,13 @@
    "source": [
     "### Write the agent code\n",
     "\n",
-    "The generated `main.py` is a full-featured template with streaming and an MCP client. Replace it with the smallest agent that satisfies the AgentCore Runtime contract, so the contract itself is easy to see:\n",
+    "Replace the generated `main.py` with a minimal agent that shows the AgentCore Runtime contract:\n",
     "\n",
-    "- `BedrockAgentCoreApp` provides the HTTP server that AgentCore Runtime expects, including the `/invocations` and `/ping` endpoints\n",
+    "- `BedrockAgentCoreApp` provides the HTTP server AgentCore Runtime expects, including the `/invocations` and `/ping` endpoints\n",
     "- The function decorated with `@app.entrypoint` receives the request payload and returns the response\n",
-    "- `app.run()` starts the server when the file is executed\n",
+    "- `app.run()` starts the server\n",
     "\n",
-    "The generated `pyproject.toml` already lists `bedrock-agentcore` and `strands-agents`, so no dependency changes are needed. The template's unused helper packages are removed to keep the deployment package small."
+    "The generated `pyproject.toml` already lists `bedrock-agentcore` and `strands-agents`, so the dependencies need no change. Remove the template modules that the minimal agent does not import."
    ]
   },
   {
@@ -276,11 +250,11 @@
     "Deploy the project from inside the project directory. The `-y` flag skips the confirmation prompt. This command:\n",
     "\n",
     "- Bootstraps the AWS CDK in your account and Region if this is the first CDK deployment there\n",
-    "- Resolves the agent's dependencies with `uv` for the arm64 architecture that AgentCore Runtime uses, and packages them with the code as a zip archive\n",
+    "- Resolves the agent's dependencies with `uv` for arm64 and packages them with the code as a zip archive\n",
     "- Uploads the archive to the CDK staging bucket in Amazon S3\n",
-    "- Synthesizes and deploys an AWS CloudFormation stack that creates the IAM execution role and the AgentCore Runtime\n",
+    "- Deploys an AWS CloudFormation stack that creates the IAM execution role and the AgentCore Runtime\n",
     "\n",
-    "The first deployment takes a few minutes. Later deployments only change what differs."
+    "The first deployment takes a few minutes. Later deployments update only what changed."
    ]
   },
   {
@@ -321,9 +295,7 @@
    "cell_type": "markdown",
    "id": "d1d444c7-0a62-428f-8327-3391d6192f42",
    "metadata": {},
-   "source": [
-    "Get the runtime ARN for use with boto3. The CLI names the runtime `agentcorelab_hello_agent`, and `get_runtime_arn` looks it up by that name."
-   ]
+   "source": "The CLI records each deployed agent's runtime ARN in the project's deployment state file. Read it from there. The boto3 calls below need the ARN to address the agent."
   },
   {
    "cell_type": "code",
@@ -331,9 +303,7 @@
    "id": "7b16f0e9-7d06-4651-8ebd-16b83a1d1fba",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "hello_runtime_arn = get_runtime_arn(PROJECT_NAME, hello_agent_name)"
-   ]
+   "source": "DEPLOYED_STATE = f\"{PROJECT_NAME}/agentcore/.cli/deployed-state.json\"\n\nwith open(DEPLOYED_STATE) as f:\n    resources = json.load(f)[\"targets\"][\"default\"][\"resources\"]\n\nhello_runtime_arn = resources[\"runtimes\"][hello_agent_name][\"runtimeArn\"]\nprint(hello_runtime_arn)"
   },
   {
    "cell_type": "markdown",
@@ -342,9 +312,7 @@
    "source": [
     "### Invoke the agent\n",
     "\n",
-    "Invoke the agent twice, once each way.\n",
-    "\n",
-    "First with the CLI, which is the quick check you would run from a terminal after a deployment:"
+    "Invoke the deployed agent two ways, first with the CLI and then with boto3."
    ]
   },
   {
@@ -364,7 +332,7 @@
    "id": "20e2412e-4519-4aec-bb62-6fbbc3985785",
    "metadata": {},
    "source": [
-    "Then with boto3, which is what an application does. `invoke_agent_runtime` on the AgentCore data plane client takes the runtime ARN, a session ID, and the request payload as bytes. The `DEFAULT` qualifier selects the endpoint the deployment created. The response body is a stream; read it and parse the JSON to get back the dictionary that the entrypoint returned, in this case `{\"result\": <message>}`."
+    "Now with boto3, using the `InvokeAgentRuntime` API."
    ]
   },
   {
@@ -397,9 +365,7 @@
    "source": [
     "### Clean up Hello Agent resources\n",
     "\n",
-    "Removing an agent takes two commands. `agentcore remove agent` deletes the agent from `agentcore.json`. The following `agentcore deploy` applies that change, and AWS CloudFormation deletes the runtime and its execution role. The cell starts with `set -e` so the script stops at the first failing command.\n",
-    "\n",
-    "Then verify with boto3 that the runtime is gone. A cleanup that only reports success has not proven anything; `assert_runtimes_absent` lists the runtimes in the account and raises if the agent is still there."
+    "Removing an agent takes two commands. `agentcore remove agent` deletes it from `agentcore.json`, and `agentcore deploy` applies that change so AWS CloudFormation deletes the runtime and its execution role.\n"
    ]
   },
   {
@@ -414,16 +380,6 @@
     "cd agentcorelab\n",
     "agentcore remove agent --name hello_agent -y\n",
     "agentcore deploy -y"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ecf405f9-1b4d-469b-8f53-3f1202ac5f74",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert_runtimes_absent(PROJECT_NAME, hello_agent_name)"
    ]
   },
   {
@@ -521,7 +477,7 @@
    "id": "a47feefb-f2ed-4404-82e0-8d5a19a88353",
    "metadata": {},
    "source": [
-    "The restaurant agent's code lives outside the CLI project, in a `restaurant_agent/` directory, and is added to the project as \"bring your own\" code in a later step. Create the directory first."
+    "The restaurant agent's code lives in its own `restaurant_agent/` directory, outside the CLI project. A later step registers it with the project."
    ]
   },
   {
@@ -891,16 +847,16 @@
    "source": [
     "### Create Execution Role\n",
     "\n",
-    "For the Hello Agent, the CLI created the execution role. The restaurant agent needs permissions beyond the standard runtime set, so create the role with boto3 and hand its ARN to the CLI.\n",
+    "The CLI created an execution role for the Hello Agent automatically. This agent needs more permissions, so create the role with boto3 and give its ARN to the CLI.\n",
     "\n",
-    "`create_execution_role` in `utils.py` starts from the permissions every agent on AgentCore Runtime needs:\n",
+    "The base permissions are the ones every agent on AgentCore Runtime needs:\n",
     "\n",
     "- Write logs to Amazon CloudWatch Logs and send traces to AWS X-Ray\n",
     "- Publish metrics to Amazon CloudWatch\n",
     "- Invoke Amazon Bedrock foundation models\n",
     "- Retrieve workload identity tokens\n",
     "\n",
-    "The `extra_statements` argument adds what this agent's business logic needs:\n",
+    "This agent adds permissions to:\n",
     "\n",
     "- Query Amazon Bedrock Knowledge Bases for restaurant information\n",
     "- Read and write booking data in Amazon DynamoDB\n",
@@ -949,9 +905,9 @@
    "source": [
     "### Add the agent to the project\n",
     "\n",
-    "`agentcore add agent --type byo` registers existing code with the project instead of generating a template. It records the code location and entrypoint in `agentcore.json` and leaves your files untouched.\n",
+    "`agentcore add agent --type byo` registers existing code with the project instead of generating a template. It records the code location and entrypoint in `agentcore.json` and leaves your files unchanged.\n",
     "\n",
-    "The CLI has no flag for an existing execution role, so the next cell edits the agent's entry in `agentcore.json` directly to set `executionRoleArn` and pin `runtimeVersion`. It prints the updated entry."
+    "The CLI has no flag for an existing execution role, so set `executionRoleArn` in `agentcore.json` directly, along with the Python runtime version."
    ]
   },
   {
@@ -1045,23 +1001,13 @@
    "id": "53cf88f3-66e3-4e55-8d5d-d78d97198683",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "prod_runtime_arn = get_runtime_arn(PROJECT_NAME, prod_agent_name)"
-   ]
+   "source": "with open(DEPLOYED_STATE) as f:\n    resources = json.load(f)[\"targets\"][\"default\"][\"resources\"]\n\nprod_runtime_arn = resources[\"runtimes\"][prod_agent_name][\"runtimeArn\"]\nprint(prod_runtime_arn)"
   },
   {
    "cell_type": "markdown",
    "id": "45d96238-d4d4-4609-878f-5a5cb53de81f",
    "metadata": {},
-   "source": [
-    "## Step 3: Test the Agent\n",
-    "\n",
-    "Test the deployed agent by sending requests through the AgentCore data plane with boto3, the same call an application makes.\n",
-    "\n",
-    "### Create a helper function\n",
-    "\n",
-    "Define a helper around `invoke_agent_runtime` so the test cells stay short. Reusing a session ID continues a conversation; omitting it starts a new one. The restaurant agent's entrypoint returns plain text, so the parsed body is the response string. The helper returns that text and the session ID."
-   ]
+   "source": "## Step 3: Test the Agent\n\nTest the deployed agent by calling `InvokeAgentRuntime` with boto3.\n\n### Create a helper function\n\nThis helper wraps the call. Passing a session ID continues a conversation, and omitting it starts a new one. The restaurant agent's entrypoint returns plain text, so the parsed response body is the reply itself."
   },
   {
    "cell_type": "code",
@@ -1237,7 +1183,7 @@
    "id": "fcb3fd85-1d8b-4751-8aca-9e2b40c38a99",
    "metadata": {},
    "source": [
-    "The agent remembered the reservation details from the previous messages and updated the party size without requiring additional information."
+    "Ask the agent to change the booking. Because this is the same session, it still has the reservation details from the earlier messages."
    ]
   },
   {
@@ -1361,15 +1307,11 @@
    "source": [
     "## Step 5: Clean up\n",
     "\n",
-    "Delete all resources created during this tutorial. These cells:\n",
+    "Delete the resources created in this tutorial. `agentcore remove all` empties `agentcore.json`, and `agentcore deploy` applies that change so AWS CloudFormation deletes the remaining runtime and the stack itself. The execution role and the local directories are deleted separately.\n",
     "\n",
-    "- Read the CloudFormation stack name from the CLI's deployment state file, so it can be checked after deletion\n",
-    "- Run `agentcore remove all`, which empties `agentcore.json`, then `agentcore deploy`, which makes CloudFormation delete the remaining runtime and the stack itself\n",
-    "- Verify with boto3 that neither runtime exists and that the stack is gone, and raise if either check fails\n",
-    "- Delete the execution role created in Step 2\n",
-    "- Remove the local project and agent directories\n",
+    "Start by reading the stack name from the project's deployment state, so it can be checked after deletion.\n",
     "\n",
-    "The CDK bootstrap stack (`CDKToolkit`) stays. It is shared account infrastructure for any CDK deployment, holds no agent resources, and costs nothing while idle. If this was a throwaway account, delete that stack from the AWS CloudFormation console."
+    "The CDK bootstrap stack (`CDKToolkit`) remains. It is shared infrastructure for any CDK deployment in the account, holds no agent resources, and costs nothing while idle."
    ]
   },
   {
@@ -1378,11 +1320,7 @@
    "id": "ae6c5aa2-e41a-4351-9248-69d3768a851c",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "with open(f\"{PROJECT_NAME}/agentcore/.cli/deployed-state.json\") as f:\n",
-    "    STACK_NAME = json.load(f)[\"targets\"][\"default\"][\"resources\"][\"stackName\"]\n",
-    "print(f\"Stack: {STACK_NAME}\")"
-   ]
+   "source": "with open(DEPLOYED_STATE) as f:\n    STACK_NAME = json.load(f)[\"targets\"][\"default\"][\"resources\"][\"stackName\"]\nprint(f\"Stack: {STACK_NAME}\")"
   },
   {
    "cell_type": "code",

--- a/python/02-deploy/03-agentcore/deploy-agent.ipynb
+++ b/python/02-deploy/03-agentcore/deploy-agent.ipynb
@@ -130,7 +130,28 @@
    "id": "9be06b4f-973a-4c3e-a5ee-4dfb70715525",
    "metadata": {},
    "outputs": [],
-   "source": "import boto3, json, time, uuid, os, re\nfrom utils import (\n    create_execution_role,\n    delete_execution_role,\n    assert_runtimes_absent,\n    assert_stack_absent,\n)\n\nsession = boto3.Session()\nregion = session.region_name or \"us-east-1\"\naccount_id = boto3.client(\"sts\").get_caller_identity()[\"Account\"]\nprint(f\"Region: {region} | Account: {account_id}\")\n\n# Data plane client used to invoke deployed agents\nagentcore_client = boto3.client(\"bedrock-agentcore\", region_name=region)\n\n# One CLI project holds both agents in this tutorial. Project names must be alphanumeric.\n# The CLI commands below use the same names as literals, so they can be copied into a terminal.\nPROJECT_NAME = \"agentcorelab\"\nhello_agent_name = \"hello_agent\"\nprod_agent_name = \"strands_restaurant_agent\"\nPYTHON_RUNTIME = \"PYTHON_3_13\""
+   "source": [
+    "import boto3, json, time, uuid, os, re\n",
+    "from utils import (\n",
+    "    create_execution_role,\n",
+    "    delete_execution_role,\n",
+    ")\n",
+    "\n",
+    "session = boto3.Session()\n",
+    "region = session.region_name or \"us-east-1\"\n",
+    "account_id = boto3.client(\"sts\").get_caller_identity()[\"Account\"]\n",
+    "print(f\"Region: {region} | Account: {account_id}\")\n",
+    "\n",
+    "# Data plane client used to invoke deployed agents\n",
+    "agentcore_client = boto3.client(\"bedrock-agentcore\", region_name=region)\n",
+    "\n",
+    "# One CLI project holds both agents in this tutorial. Project names must be alphanumeric.\n",
+    "# The CLI commands below use the same names as literals, so they can be copied into a terminal.\n",
+    "PROJECT_NAME = \"agentcorelab\"\n",
+    "hello_agent_name = \"hello_agent\"\n",
+    "prod_agent_name = \"strands_restaurant_agent\"\n",
+    "PYTHON_RUNTIME = \"PYTHON_3_13\""
+   ]
   },
   {
    "cell_type": "markdown",
@@ -1309,18 +1330,8 @@
     "\n",
     "Delete the resources created in this tutorial. `agentcore remove all` empties `agentcore.json`, and `agentcore deploy` applies that change so AWS CloudFormation deletes the remaining runtime and the stack itself. The execution role and the local directories are deleted separately.\n",
     "\n",
-    "Start by reading the stack name from the project's deployment state, so it can be checked after deletion.\n",
-    "\n",
-    "The CDK bootstrap stack (`CDKToolkit`) remains. It is shared infrastructure for any CDK deployment in the account, holds no agent resources, and costs nothing while idle."
+    "The CDK bootstrap stack (`CDKToolkit`) remains. It is shared infrastructure for any CDK deployment in the account, holds no agent resources, and costs nothing while idle.\n"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ae6c5aa2-e41a-4351-9248-69d3768a851c",
-   "metadata": {},
-   "outputs": [],
-   "source": "with open(DEPLOYED_STATE) as f:\n    STACK_NAME = json.load(f)[\"targets\"][\"default\"][\"resources\"][\"stackName\"]\nprint(f\"Stack: {STACK_NAME}\")"
   },
   {
    "cell_type": "code",
@@ -1343,9 +1354,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "assert_runtimes_absent(PROJECT_NAME, hello_agent_name, prod_agent_name)\n",
-    "assert_stack_absent(STACK_NAME)\n",
-    "delete_execution_role(prod_agent_name)"
+    "delete_execution_role(prod_agent_name)\n"
    ]
   },
   {

--- a/python/02-deploy/03-agentcore/deploy-agent.ipynb
+++ b/python/02-deploy/03-agentcore/deploy-agent.ipynb
@@ -18,7 +18,7 @@
    "id": "377668d9-6d31-4147-9179-5a13a86dfb90",
    "metadata": {},
    "source": [
-    "### Prerequisites\n",
+    "## Prerequisites\n",
     "\n",
     "Before starting this tutorial, ensure you have:\n",
     "\n",
@@ -26,7 +26,7 @@
     "- Python 3.12 or later\n",
     "- Node.js 20 or later\n",
     "- Access to Amazon Bedrock AgentCore\n",
-    "- Permissions to create resources with AWS CloudFormation, AWS IAM, Amazon DynamoDB, and Amazon Bedrock Knowledge Bases\n"
+    "- Permissions to create resources with AWS CloudFormation, AWS Identity and Access Management (IAM), Amazon S3, Amazon DynamoDB, Amazon OpenSearch Serverless, Amazon Bedrock Knowledge Bases, and AWS Systems Manager"
    ]
   },
   {
@@ -34,7 +34,7 @@
    "id": "4bdbeee4-9b60-4ae9-b1df-1564c0729594",
    "metadata": {},
    "source": [
-    "Install the required Python packages."
+    "Install the Python packages this tutorial uses. `boto3`, `bedrock-agentcore`, and the Strands packages run the agents. `opensearch-py` and `retrying` are used by the prerequisite script that builds the knowledge base. `uv` is used by the AgentCore CLI to resolve agent dependencies."
    ]
   },
   {
@@ -59,11 +59,11 @@
    "id": "8429bdda-8792-4380-ae12-81c487cde30e",
    "metadata": {},
    "source": [
-    "### Install the AgentCore CLI\n",
+    "## Install the AgentCore CLI\n",
     "\n",
     "The [AgentCore CLI](https://github.com/aws/agentcore-cli) is a command line tool for creating, developing, and deploying agents on Amazon Bedrock AgentCore. It scaffolds an agent project, runs the agent locally for development, deploys it to AgentCore Runtime, and manages the deployed resources.\n",
     "\n",
-    "It runs on Node.js and uses `uv` to resolve an agent's Python dependencies for the arm64 architecture that AgentCore Runtime requires."
+    "It runs on Node.js and uses `uv` to resolve an agent's Python dependencies for the arm64 architecture that AgentCore Runtime requires. Confirm both are available."
    ]
   },
   {
@@ -121,7 +121,7 @@
    "id": "088818e2-3a78-49d0-9f11-e9e0b7119d31",
    "metadata": {},
    "source": [
-    "Get the current AWS Region and account ID."
+    "Get the current AWS Region and account ID, create the data plane client used to invoke deployed agents, and set the project and agent names used throughout the tutorial."
    ]
   },
   {
@@ -131,7 +131,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import boto3, json, time, uuid, os, re\n",
+    "import boto3, json, uuid, re\n",
     "from utils import (\n",
     "    create_execution_role,\n",
     "    delete_execution_role,\n",
@@ -164,7 +164,7 @@
     "\n",
     "### Create a project\n",
     "\n",
-    "An AgentCore CLI project is a directory holding an `agentcore/agentcore.json` configuration file that lists the agents to deploy, and an `app/` directory containing each agent's code. The `create` command scaffolds both. Project names must be alphanumeric, and agent names may also contain underscores."
+    "An AgentCore CLI project is a directory holding an `agentcore/agentcore.json` configuration file whose `runtimes` array lists the agents to deploy, and an `app/` directory containing each agent's code. The `create` command scaffolds both."
    ]
   },
   {
@@ -316,7 +316,9 @@
    "cell_type": "markdown",
    "id": "d1d444c7-0a62-428f-8327-3391d6192f42",
    "metadata": {},
-   "source": "The CLI records each deployed agent's runtime ARN in the project's deployment state file. Read it from there. The boto3 calls below need the ARN to address the agent."
+   "source": [
+    "The CLI writes each deployed agent's runtime ARN to `agentcore/.cli/deployed-state.json` inside the project. Read the Hello Agent's ARN from there. The boto3 calls below need it to address the agent."
+   ]
   },
   {
    "cell_type": "code",
@@ -386,7 +388,7 @@
    "source": [
     "### Clean up Hello Agent resources\n",
     "\n",
-    "Removing an agent takes two commands. `agentcore remove agent` deletes it from `agentcore.json`, and `agentcore deploy` applies that change so AWS CloudFormation deletes the runtime and its execution role.\n"
+    "Removing an agent takes two commands. `agentcore remove agent` deletes it from `agentcore.json`, and `agentcore deploy` applies that change. Because the Hello Agent is the only agent in the project, AWS CloudFormation deletes its runtime, its execution role, and the stack itself."
    ]
   },
   {
@@ -413,7 +415,7 @@
     "The restaurant booking agent is a conversational assistant built with Strands Agents that helps customers make restaurant reservations. It demonstrates a production deployment pattern with multiple AWS service integrations:\n",
     "\n",
     "- **Amazon DynamoDB**: Stores and retrieves booking records\n",
-    "- **Amazon Bedrock Knowledge Bases**: Answers questions about restaurants and menus using RAG (Retrieval Augmented Generation)\n",
+    "- **Amazon Bedrock Knowledge Bases**: Answers questions about restaurants and menus using Retrieval Augmented Generation (RAG)\n",
     "- **AWS Systems Manager Parameter Store**: Stores configuration values such as table names and Knowledge Base IDs\n",
     "\n",
     "Unlike the Hello Agent, this agent requires a custom IAM execution role with permissions to access these AWS services."
@@ -439,8 +441,12 @@
     "Run the setup script to create the required AWS resources:\n",
     "\n",
     "- An Amazon DynamoDB table for storing bookings\n",
-    "- An Amazon Bedrock Knowledge Base with restaurant and menu data\n",
-    "- AWS Systems Manager parameters for configuration"
+    "- An Amazon S3 bucket holding the restaurant documents\n",
+    "- An Amazon OpenSearch Serverless collection used as the vector store, plus the IAM roles the knowledge base needs\n",
+    "- An Amazon Bedrock knowledge base built from those documents\n",
+    "- AWS Systems Manager parameters for configuration\n",
+    "\n",
+    "Creating the OpenSearch Serverless collection and syncing the knowledge base is the slowest and most expensive part of this tutorial, and takes several minutes."
    ]
   },
   {
@@ -458,7 +464,7 @@
    "id": "c975122d-103e-4435-a60f-deff59257bec",
    "metadata": {},
    "source": [
-    "Verify that the prerequisite resources were created successfully by reading the parameter values from Parameter Store."
+    "Read the knowledge base ID and DynamoDB table name that the setup script wrote to Parameter Store. The agent reads the same two parameters at runtime."
    ]
   },
   {
@@ -477,7 +483,7 @@
     "    kb_id = ssm.get_parameter(Name=kb_param)[\"Parameter\"][\"Value\"]\n",
     "    table_name = ssm.get_parameter(Name=table_param)[\"Parameter\"][\"Value\"]\n",
     "    print(\"✅ Prereqs verified\")\n",
-    "    print(\"Knowledge Base ID:\", kb_id)\n",
+    "    print(\"Knowledge base ID:\", kb_id)\n",
     "    print(\"DynamoDB Table:\", table_name)\n",
     "except Exception as e:\n",
     "    raise RuntimeError(f\"Prereq verification failed: {e}\")"
@@ -725,7 +731,13 @@
     "The `@app.entrypoint` decorator marks the function as the handler for incoming requests. It receives:\n",
     "\n",
     "- `payload`: The request data containing the user's prompt\n",
-    "- `context`: Session information including the session ID for maintaining conversation state"
+    "- `context`: Session information including the session ID for maintaining conversation state\n",
+    "\n",
+    "Three details in the code are worth noting:\n",
+    "\n",
+    "- The knowledge base ID is read from Parameter Store and set as the `KNOWLEDGE_BASE_ID` environment variable before `retrieve` is imported, because that tool reads the variable at import time\n",
+    "- The agent gets two tools beyond the booking tools written above: `retrieve` queries the knowledge base, and `current_time` supplies the current date and time\n",
+    "- The model is pinned to Anthropic Claude Sonnet with extended thinking disabled"
    ]
   },
   {
@@ -866,9 +878,9 @@
    "id": "92c068cb-e714-4a0e-a83a-1a20017b8a36",
    "metadata": {},
    "source": [
-    "### Create Execution Role\n",
+    "### Create the execution role\n",
     "\n",
-    "The CLI created an execution role for the Hello Agent automatically. This agent needs more permissions, so create the role with boto3 and give its ARN to the CLI.\n",
+    "For the Hello Agent, the CloudFormation stack created an execution role automatically. This agent needs more permissions, so create the role with boto3 and give its ARN to the CLI.\n",
     "\n",
     "The base permissions are the ones every agent on AgentCore Runtime needs:\n",
     "\n",
@@ -928,7 +940,7 @@
     "\n",
     "`agentcore add agent --type byo` registers existing code with the project instead of generating a template. It records the code location and entrypoint in `agentcore.json` and leaves your files unchanged.\n",
     "\n",
-    "The CLI has no flag for an existing execution role, so set `executionRoleArn` in `agentcore.json` directly, along with the Python runtime version."
+    "Set `executionRoleArn` in `agentcore.json` to use the role created above, and `runtimeVersion` to choose the Python version AgentCore Runtime runs the agent with."
    ]
   },
   {
@@ -979,7 +991,7 @@
    "source": [
     "### Deploy to AgentCore Runtime\n",
     "\n",
-    "Deploy the project again. CloudFormation adds the restaurant agent's runtime to the existing stack. Because the execution role already exists, the stack references it instead of creating one."
+    "Deploy the project again. CloudFormation creates the stack that hosts the restaurant agent's runtime. Because `agentcore.json` sets `executionRoleArn` for this agent, the stack references that role instead of creating one."
    ]
   },
   {
@@ -999,7 +1011,7 @@
    "id": "35f3f422-eff4-4473-a708-e9445aaa6c45",
    "metadata": {},
    "source": [
-    "### Check Deployment Status\n",
+    "### Check deployment status\n",
     "\n",
     "Confirm the agent is `READY`, then look up its runtime ARN for the tests that follow."
    ]
@@ -1028,7 +1040,15 @@
    "cell_type": "markdown",
    "id": "45d96238-d4d4-4609-878f-5a5cb53de81f",
    "metadata": {},
-   "source": "## Step 3: Test the Agent\n\nTest the deployed agent by calling `InvokeAgentRuntime` with boto3.\n\n### Create a helper function\n\nThis helper wraps the call. Passing a session ID continues a conversation, and omitting it starts a new one. The restaurant agent's entrypoint returns plain text, so the parsed response body is the reply itself."
+   "source": [
+    "## Step 3: Test the agent\n",
+    "\n",
+    "Test the deployed agent by calling `InvokeAgentRuntime` with boto3.\n",
+    "\n",
+    "### Create a helper function\n",
+    "\n",
+    "This helper wraps the call. Passing a session ID continues a conversation, and omitting it starts a new one. The restaurant agent's entrypoint returns plain text, so the parsed response body is the reply itself."
+   ]
   },
   {
    "cell_type": "code",
@@ -1058,7 +1078,7 @@
    "source": [
     "### Test basic functionality\n",
     "\n",
-    "Test the agent's core capabilities: creating bookings, querying the Knowledge Base, and retrieving booking details."
+    "Test the agent's core capabilities: creating bookings, querying the knowledge base, and retrieving booking details."
    ]
   },
   {
@@ -1100,8 +1120,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ---------- Test 2: Knowledge Base query ----------\n",
-    "print(\"Test 2: Knowledge Base query\")\n",
+    "# ---------- Test 2: Knowledge base query ----------\n",
+    "print(\"Test 2: Knowledge base query\")\n",
     "print(\"-\" * 50)\n",
     "\n",
     "user_query = \"What's on the menu at Nonna's Hearth? Do they have vegetarian options?\"\n",
@@ -1132,9 +1152,9 @@
    "id": "bb3aabde-0391-4083-a1df-a1ae49ace289",
    "metadata": {},
    "source": [
-    "## Step 4: Session Management\n",
+    "## Step 4: Session management\n",
     "\n",
-    "AgentCore Runtime provides built-in session management for stateful conversations. Each session maintains context across multiple interactions, and sessions are isolated from each other."
+    "AgentCore Runtime routes every request carrying the same `runtimeSessionId` to the same session, each running in its own microVM. Because the Strands agent object is created once when the agent starts, its conversation history stays in memory for the life of that session, and no session can see another session's state."
    ]
   },
   {
@@ -1204,7 +1224,7 @@
    "id": "fcb3fd85-1d8b-4751-8aca-9e2b40c38a99",
    "metadata": {},
    "source": [
-    "Ask the agent to change the booking. Because this is the same session, it still has the reservation details from the earlier messages."
+    "Ask the agent to change the party size. The agent has no update tool, so it cancels the existing booking and creates a new one, using the restaurant, date, and time it already has from earlier messages in this session."
    ]
   },
   {
@@ -1243,7 +1263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# New session that should not “remember” the previous conversation\n",
+    "# New session that should not \"remember\" the previous conversation\n",
     "user_session_id_2 = str(uuid.uuid4())\n",
     "print(f\"Starting new session: {user_session_id_2}\")\n",
     "print(\"-\" * 60)\n",
@@ -1295,7 +1315,7 @@
     "            print(\"  Party Size:     \", item.get(\"party_size\"))\n",
     "            print(\"  Status:         \", item.get(\"status\"))\n",
     "        else:\n",
-    "            print(f\"⚠️  No booking found (id={booking_id}, restaurant={restaurant_name})\")\n",
+    "            print(f\"❌ No booking found (id={booking_id}, restaurant={restaurant_name})\")\n",
     "    except Exception as e:\n",
     "        print(f\"❌ Error querying booking: {e}\")\n",
     "\n",
@@ -1303,7 +1323,7 @@
     "if booking_id:\n",
     "    query_specific_booking(booking_id, \"Ocean Harvest\")\n",
     "else:\n",
-    "    print(\"⚠️  Skipping DB check: no booking_id captured.\")"
+    "    print(\"❌ Skipping DB check: no booking_id captured.\")"
    ]
   },
   {
@@ -1313,12 +1333,11 @@
    "source": [
     "### Session management summary\n",
     "\n",
-    "AgentCore Runtime session management provides:\n",
+    "AgentCore Runtime session handling provides:\n",
     "\n",
-    "- **Conversation continuity**: Context is maintained across multiple interactions within a session\n",
-    "- **Session isolation**: Each session is independent with no shared state\n",
-    "- **Automatic handling**: No manual session state management required\n",
-    "- **Scalability**: Sessions scale automatically with application demand"
+    "- **Conversation continuity**: Requests sharing a `runtimeSessionId` reach the same session, so the agent keeps its history for the life of that session\n",
+    "- **Session isolation**: Each session runs in its own microVM and shares no state with any other session\n",
+    "- **Ephemeral state**: Session state is held in memory only. It is lost when the session ends, which happens after 15 minutes idle by default. Use Amazon Bedrock AgentCore Memory for conversation history that must outlive a session"
    ]
   },
   {
@@ -1330,7 +1349,7 @@
     "\n",
     "Delete the resources created in this tutorial. `agentcore remove all` empties `agentcore.json`, and `agentcore deploy` applies that change so AWS CloudFormation deletes the remaining runtime and the stack itself. The execution role and the local directories are deleted separately.\n",
     "\n",
-    "The CDK bootstrap stack (`CDKToolkit`) remains. It is shared infrastructure for any CDK deployment in the account, holds no agent resources, and costs nothing while idle.\n"
+    "The CDK bootstrap stack (`CDKToolkit`) remains. It is shared infrastructure for any CDK deployment in the account and holds no agent resources, but its staging bucket in Amazon S3 retains the deployment archives uploaded by each deploy, which incur storage charges. Delete that stack only if no other CDK application in this account and Region depends on it."
    ]
   },
   {
@@ -1380,7 +1399,7 @@
     }
    },
    "source": [
-    "Delete the prerequisite infrastructure (Amazon DynamoDB table, Amazon Bedrock Knowledge Base, and AWS Systems Manager parameters)."
+    "Delete the prerequisite infrastructure: the Amazon DynamoDB table, the Amazon Bedrock knowledge base and its Amazon OpenSearch Serverless collection, the Amazon S3 bucket holding the documents, the IAM roles created for the knowledge base, and the AWS Systems Manager parameters."
    ]
   },
   {

--- a/python/02-deploy/03-agentcore/deploy-agent.ipynb
+++ b/python/02-deploy/03-agentcore/deploy-agent.ipynb
@@ -2,30 +2,20 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "88c1975b-496d-413c-a75c-d2011cba87d0",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-20T18:42:28.246745Z",
-     "iopub.status.busy": "2025-10-20T18:42:28.246496Z",
-     "iopub.status.idle": "2025-10-20T18:42:28.250719Z",
-     "shell.execute_reply": "2025-10-20T18:42:28.249966Z",
-     "shell.execute_reply.started": "2025-10-20T18:42:28.246725Z"
-    }
-   },
+   "id": "5facf0b5-015c-4885-bb5e-a1ea352519fb",
+   "metadata": {},
    "source": [
     "# Deploying Strands Agents on Amazon Bedrock AgentCore Runtime\n",
     "\n",
     "This tutorial shows you how to deploy Strands Agents to Amazon Bedrock AgentCore Runtime, a fully managed runtime for hosting AI agents. You will deploy two agents:\n",
     "\n",
     "1. A minimal \"Hello Agent\" that demonstrates the basic deployment workflow\n",
-    "2. A restaurant booking assistant with tools for creating, retrieving, and deleting reservations\n",
-    "\n",
-    "By the end of this tutorial, you will have deployed a production-ready agent with Amazon DynamoDB integration, Amazon Bedrock Knowledge Base retrieval, and automatic session management."
+    "2. A restaurant booking assistant with Amazon DynamoDB integration, Amazon Bedrock Knowledge Base retrieval, and session management\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "540d002c-358f-4a21-8fe2-05534c027581",
+   "id": "377668d9-6d31-4147-9179-5a13a86dfb90",
    "metadata": {},
    "source": [
     "### Prerequisites\n",
@@ -34,14 +24,9 @@
     "\n",
     "- [AWS CLI](https://aws.amazon.com/cli/) installed and configured\n",
     "- Python 3.12 or later\n",
+    "- Node.js 20 or later\n",
     "- Access to Amazon Bedrock AgentCore\n",
-    "- The following AWS services enabled:\n",
-    "  - Amazon Bedrock\n",
-    "  - Amazon ECR\n",
-    "  - AWS IAM\n",
-    "  - Amazon DynamoDB\n",
-    "  - Amazon Bedrock Knowledge Bases\n",
-    "  - AWS Systems Manager Parameter Store"
+    "- Permissions to create resources with AWS CloudFormation, AWS IAM, Amazon DynamoDB, and Amazon Bedrock Knowledge Bases\n"
    ]
   },
   {
@@ -61,12 +46,74 @@
    "source": [
     "!pip install -q --upgrade \\\n",
     "  boto3 \\\n",
-    "  bedrock-agentcore-starter-toolkit \\\n",
     "  bedrock-agentcore \\\n",
     "  strands-agents \\\n",
     "  strands-agents-tools \\\n",
     "  opensearch-py \\\n",
-    "  retrying"
+    "  retrying \\\n",
+    "  uv"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8429bdda-8792-4380-ae12-81c487cde30e",
+   "metadata": {},
+   "source": [
+    "### Install the AgentCore CLI\n",
+    "\n",
+    "The [AgentCore CLI](https://github.com/aws/agentcore-cli) is a command line tool that creates an agent project, packages the code as a zip archive, and deploys it to Amazon Bedrock AgentCore Runtime through AWS CloudFormation. It needs Node.js 20 or later to run and `uv` (installed above) to resolve the agent's Python dependencies for the arm64 runtime. Confirm both are available.\n",
+    "\n",
+    "Cells that start with `%%bash` run their contents as a shell script. Unlike a `!` command, a `%%bash` cell raises an error when the script exits with a non-zero status, so a failed CLI command stops the notebook instead of scrolling past.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1511c2ca-f262-4e1a-aad0-831f3fe6b071",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "node --version\n",
+    "uv --version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "298364de-ad6b-4cbb-b360-7fa05f19d52a",
+   "metadata": {},
+   "source": [
+    "Install the AgentCore CLI globally with npm. This is the same command the AWS Developer Guide uses."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35c3d1bb-231b-4e3e-aca1-59d215503da8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "npm install -g @aws/agentcore@0.28.1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "acf9f170-5251-4af7-9de4-80fcf8f029ed",
+   "metadata": {},
+   "source": [
+    "Confirm the installed version.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c585025f-6eac-4a4a-8022-6fbe084cb176",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "agentcore --version"
    ]
   },
   {
@@ -85,34 +132,113 @@
    "outputs": [],
    "source": [
     "import boto3, json, time, uuid, os, re\n",
+    "from utils import (\n",
+    "    create_execution_role,\n",
+    "    delete_execution_role,\n",
+    "    get_runtime_arn,\n",
+    "    assert_runtimes_absent,\n",
+    "    assert_stack_absent,\n",
+    ")\n",
+    "\n",
     "session = boto3.Session()\n",
     "region = session.region_name or \"us-east-1\"\n",
     "account_id = boto3.client(\"sts\").get_caller_identity()[\"Account\"]\n",
-    "print(f\"Region: {region} | Account: {account_id}\")"
+    "print(f\"Region: {region} | Account: {account_id}\")\n",
+    "\n",
+    "# Data plane client used to invoke deployed agents\n",
+    "agentcore_client = boto3.client(\"bedrock-agentcore\", region_name=region)\n",
+    "\n",
+    "# One CLI project holds both agents in this tutorial. Project names must be alphanumeric.\n",
+    "# The CLI commands below use the same names as literals, so they can be copied into a terminal.\n",
+    "PROJECT_NAME = \"agentcorelab\"\n",
+    "hello_agent_name = \"hello_agent\"\n",
+    "prod_agent_name = \"strands_restaurant_agent\"\n",
+    "PYTHON_RUNTIME = \"PYTHON_3_13\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b9e6bf2d-e0c6-4a69-a126-04015d666d99",
+   "id": "c1002986-f909-4993-8534-4dea971635cf",
    "metadata": {},
    "source": [
     "## Step 1: Deploy a Hello Agent\n",
     "\n",
-    "Start by deploying a minimal agent that demonstrates the basic deployment workflow: configure, deploy, and invoke.\n",
+    "Start by deploying a minimal agent that demonstrates the basic deployment workflow: create a project, deploy, invoke, and remove.\n",
     "\n",
-    "### Create the agent source file\n",
+    "### Create a project with the AgentCore CLI\n",
     "\n",
-    "Create `hello_agent.py` with the following code:"
+    "The AgentCore CLI works on a project: a directory with an `agentcore/agentcore.json` configuration file that lists the agents to deploy, plus an `app/` directory holding each agent's code. The `create` command scaffolds all of it.\n",
+    "\n",
+    "The commands in this tutorial are the same ones you would run in a terminal. Project names must be alphanumeric, and agent names allow underscores."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f695231-7cc8-43f6-afaa-791dc407f841",
+   "id": "de5cae1a-ebd1-4086-a30d-55473a8f3b73",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile hello_agent.py\n",
+    "%%bash\n",
+    "agentcore create \\\n",
+    "  --project-name agentcorelab \\\n",
+    "  --name hello_agent \\\n",
+    "  --framework Strands \\\n",
+    "  --model-provider Bedrock \\\n",
+    "  --memory none \\\n",
+    "  --skip-git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3edc5d20-9a10-4ee7-8276-e4cf3850e8aa",
+   "metadata": {},
+   "source": [
+    "This command:\n",
+    "\n",
+    "- Creates the `agentcorelab/` project directory\n",
+    "- Writes `agentcore/agentcore.json`, which declares one agent named `hello_agent` with `build: CodeZip`, an entrypoint of `main.py`, and the Python runtime version\n",
+    "- Generates a starter agent under `app/hello_agent/` with a `pyproject.toml` that lists its dependencies\n",
+    "- Runs `uv sync` to create a local virtual environment for the agent\n",
+    "\n",
+    "Inspect the project layout and the configuration file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76b27e31-7834-4a18-bb3c-d030d9e07e51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!find agentcorelab -maxdepth 3 -not -path '*/.venv*' -not -path '*/cdk*' -not -path '*/.llm-context*' -not -path '*/.cli*' | sort\n",
+    "!cat agentcorelab/agentcore/agentcore.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f6fa7dc-daa8-47f5-a269-e1904960b75f",
+   "metadata": {},
+   "source": [
+    "### Write the agent code\n",
+    "\n",
+    "The generated `main.py` is a full-featured template with streaming and an MCP client. Replace it with the smallest agent that satisfies the AgentCore Runtime contract, so the contract itself is easy to see:\n",
+    "\n",
+    "- `BedrockAgentCoreApp` provides the HTTP server that AgentCore Runtime expects, including the `/invocations` and `/ping` endpoints\n",
+    "- The function decorated with `@app.entrypoint` receives the request payload and returns the response\n",
+    "- `app.run()` starts the server when the file is executed\n",
+    "\n",
+    "The generated `pyproject.toml` already lists `bedrock-agentcore` and `strands-agents`, so no dependency changes are needed. The template's unused helper packages are removed to keep the deployment package small."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "732f04ce-4f5c-408a-ab5e-add1228155cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writefile agentcorelab/app/hello_agent/main.py\n",
     "from bedrock_agentcore import BedrockAgentCoreApp\n",
     "from strands import Agent\n",
     "\n",
@@ -131,148 +257,173 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "239735e4-8c47-4c55-b09c-64bf49e0a005",
-   "metadata": {},
-   "source": [
-    "Create `requirements-hello.txt` with the agent dependencies:"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25ab1829-369f-4f5f-9e1f-8531a6997ae1",
+   "id": "913b7763-aee5-4d90-8b37-9d4b210fa87d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile requirements-hello.txt\n",
-    "bedrock-agentcore\n",
-    "strands-agents"
+    "!rm -rf agentcorelab/app/hello_agent/mcp_client agentcorelab/app/hello_agent/skills agentcorelab/app/hello_agent/model"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fa5a5726-3ef1-4a45-8dc6-dbc39029c4bc",
-   "metadata": {},
-   "source": [
-    "### Configure the agent\n",
-    "\n",
-    "The [Amazon Bedrock AgentCore Starter Toolkit](https://pypi.org/project/bedrock-agentcore-starter-toolkit/) is a Python SDK that simplifies deploying agents to Amazon Bedrock AgentCore Runtime. It provides a programmatic interface for configuring, building, deploying, and invoking agents without needing to manage container images, IAM roles, or AWS infrastructure directly."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8d96effa-4ab9-4ef9-bfb5-3f002cffe3f6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from bedrock_agentcore_starter_toolkit import Runtime\n",
-    "from boto3.session import Session\n",
-    "\n",
-    "boto_session = Session()\n",
-    "agentcore_runtime_hello = Runtime()\n",
-    "hello_agent_name = \"hello_agentcore_quickstart\"\n",
-    "\n",
-    "hello_cfg = agentcore_runtime_hello.configure(\n",
-    "    entrypoint=\"hello_agent.py\",\n",
-    "    auto_create_execution_role=True,\n",
-    "    auto_create_ecr=True,\n",
-    "    requirements_file=\"requirements-hello.txt\",\n",
-    "    agent_name=hello_agent_name\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "74f8664e-f229-4711-a77c-e11b6a6758da",
+   "id": "c9d488f2-ddea-4fd8-a5ad-e8b2d4087df8",
    "metadata": {},
    "source": [
     "### Deploy to AgentCore Runtime\n",
     "\n",
-    "Launch the agent to AgentCore Runtime. This command:\n",
+    "Deploy the project from inside the project directory. The `-y` flag skips the confirmation prompt. This command:\n",
     "\n",
-    "- Builds the container image using AWS CodeBuild\n",
-    "- Creates the Amazon ECR repository and IAM execution role\n",
-    "- Deploys the agent to AgentCore Runtime\n",
-    "- Configures Amazon CloudWatch logging"
+    "- Bootstraps the AWS CDK in your account and Region if this is the first CDK deployment there\n",
+    "- Resolves the agent's dependencies with `uv` for the arm64 architecture that AgentCore Runtime uses, and packages them with the code as a zip archive\n",
+    "- Uploads the archive to the CDK staging bucket in Amazon S3\n",
+    "- Synthesizes and deploys an AWS CloudFormation stack that creates the IAM execution role and the AgentCore Runtime\n",
+    "\n",
+    "The first deployment takes a few minutes. Later deployments only change what differs."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "027e9c42-06a1-4536-bf7d-82a073e479e8",
+   "id": "bee84cf8-8caf-4079-bb92-a30600ab246f",
    "metadata": {},
    "outputs": [],
    "source": [
-    "hello_launch = agentcore_runtime_hello.launch()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "99675272-cb6c-461b-89d7-45c01280780c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "hello_status = agentcore_runtime_hello.status()\n",
-    "status = hello_status.endpoint[\"status\"]\n",
-    "terminal = {\"READY\",\"CREATE_FAILED\",\"DELETE_FAILED\",\"UPDATE_FAILED\"}\n",
-    "while status not in terminal:\n",
-    "    print(\"Tiny agent status:\", status)\n",
-    "    time.sleep(8)\n",
-    "    hello_status = agentcore_runtime_hello.status()\n",
-    "    status = hello_status.endpoint[\"status\"]\n",
-    "\n",
-    "print(\"Final tiny agent status:\", status)"
+    "%%bash\n",
+    "cd agentcorelab\n",
+    "agentcore deploy -y"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "dc9a1632-9be1-4d0c-a46b-736b536d8d64",
+   "id": "fab855a9-4066-4cea-bacb-884533bdf6bf",
+   "metadata": {},
+   "source": [
+    "### Check deployment status\n",
+    "\n",
+    "`agentcore status` reports each resource in the project and its state."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3361a67-304b-4662-9f9e-9487bd2592f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "cd agentcorelab\n",
+    "agentcore status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1d444c7-0a62-428f-8327-3391d6192f42",
+   "metadata": {},
+   "source": [
+    "Get the runtime ARN for use with boto3. The CLI names the runtime `agentcorelab_hello_agent`, and `get_runtime_arn` looks it up by that name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b16f0e9-7d06-4651-8ebd-16b83a1d1fba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hello_runtime_arn = get_runtime_arn(PROJECT_NAME, hello_agent_name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab6649e7-50cd-496e-a561-95a3b9913c3a",
    "metadata": {},
    "source": [
     "### Invoke the agent\n",
     "\n",
-    "Send a request to the deployed agent using the Starter Toolkit's `invoke()` method."
+    "Invoke the agent twice, once each way.\n",
+    "\n",
+    "First with the CLI, which is the quick check you would run from a terminal after a deployment:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ccaa843-2db6-4ca6-8cfb-00b3de126e72",
+   "id": "167db4f5-8453-48f0-8776-f98f61aeead6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "resp = agentcore_runtime_hello.invoke({\"prompt\": \"Wave if you can hear me 👋\"})\n",
-    "resp"
+    "%%bash\n",
+    "cd agentcorelab\n",
+    "agentcore invoke \"Wave if you can hear me\""
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "4a938cbf-d5d9-45f9-bd01-b2fd82c6c9d9",
+   "id": "20e2412e-4519-4aec-bb62-6fbbc3985785",
    "metadata": {},
    "source": [
-    "### Clean up Hello Agent resources\n",
-    "\n",
-    "Delete the AgentCore resources for the Hello Agent. This command removes:\n",
-    "\n",
-    "- AgentCore runtime and endpoint\n",
-    "- Amazon ECR repository and images\n",
-    "- AWS CodeBuild project\n",
-    "- IAM execution role\n",
-    "- Local deployment configuration files"
+    "Then with boto3, which is what an application does. `invoke_agent_runtime` on the AgentCore data plane client takes the runtime ARN, a session ID, and the request payload as bytes. The `DEFAULT` qualifier selects the endpoint the deployment created. The response body is a stream; read it and parse the JSON to get back the dictionary that the entrypoint returned, in this case `{\"result\": <message>}`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5fdb4fe-07af-4a76-9131-df554c8e91a1",
+   "id": "dedf6416-9cac-4620-9e4e-f7b416ae6259",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!agentcore destroy --agent $hello_agent_name --force --delete-ecr-repo  \n",
-    "!rm -f .bedrock_agentcore.yaml Dockerfile .dockerignore hello_agent.py requirements-hello.txt"
+    "session_id = str(uuid.uuid4())\n",
+    "\n",
+    "response = agentcore_client.invoke_agent_runtime(\n",
+    "    agentRuntimeArn=hello_runtime_arn,\n",
+    "    qualifier=\"DEFAULT\",\n",
+    "    runtimeSessionId=session_id,\n",
+    "    payload=json.dumps({\"prompt\": \"Wave if you can hear me\"}).encode(),\n",
+    "    contentType=\"application/json\",\n",
+    "    accept=\"application/json\",\n",
+    ")\n",
+    "\n",
+    "body = json.loads(response[\"response\"].read())\n",
+    "print(body[\"result\"][\"content\"][0][\"text\"])\n",
+    "print(f\"Session ID: {response['runtimeSessionId']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e1452ab-b9a2-41b4-8f3c-ff236e8c44ba",
+   "metadata": {},
+   "source": [
+    "### Clean up Hello Agent resources\n",
+    "\n",
+    "Removing an agent takes two commands. `agentcore remove agent` deletes the agent from `agentcore.json`. The following `agentcore deploy` applies that change, and AWS CloudFormation deletes the runtime and its execution role. The cell starts with `set -e` so the script stops at the first failing command.\n",
+    "\n",
+    "Then verify with boto3 that the runtime is gone. A cleanup that only reports success has not proven anything; `assert_runtimes_absent` lists the runtimes in the account and raises if the agent is still there."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "156fff97-d1c7-433d-b4b5-211b3df72579",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "cd agentcorelab\n",
+    "agentcore remove agent --name hello_agent -y\n",
+    "agentcore deploy -y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ecf405f9-1b4d-469b-8f53-3f1202ac5f74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert_runtimes_absent(PROJECT_NAME, hello_agent_name)"
    ]
   },
   {
@@ -367,6 +518,24 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a47feefb-f2ed-4404-82e0-8d5a19a88353",
+   "metadata": {},
+   "source": [
+    "The restaurant agent's code lives outside the CLI project, in a `restaurant_agent/` directory, and is added to the project as \"bring your own\" code in a later step. Create the directory first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27914358-8028-4157-af84-7deb7b17712e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!mkdir -p restaurant_agent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "480522bc-94ec-47b3-96e4-ddf47033ab89",
    "metadata": {},
    "source": [
@@ -382,7 +551,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile create_booking.py\n",
+    "%%writefile restaurant_agent/create_booking.py\n",
     "from strands import tool\n",
     "import boto3 \n",
     "import uuid\n",
@@ -465,7 +634,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile get_booking.py\n",
+    "%%writefile restaurant_agent/get_booking.py\n",
     "from strands import tool\n",
     "import boto3 \n",
     "import os\n",
@@ -523,7 +692,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile delete_booking.py\n",
+    "%%writefile restaurant_agent/delete_booking.py\n",
     "from strands import tool\n",
     "import boto3 \n",
     "import os\n",
@@ -589,7 +758,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile app.py\n",
+    "%%writefile restaurant_agent/app.py\n",
     "from bedrock_agentcore import BedrockAgentCoreApp\n",
     "from strands import Agent\n",
     "from strands.models import BedrockModel\n",
@@ -655,7 +824,7 @@
     "\n",
     "# Create the Strands agent\n",
     "model = BedrockModel(\n",
-    "    model_id=\"us.anthropic.claude-sonnet-4-5-20250929-v1:0\",\n",
+    "    model_id=\"us.anthropic.claude-sonnet-4-6\",\n",
     "    additional_request_fields={\"thinking\": {\"type\": \"disabled\"}}\n",
     ")\n",
     "\n",
@@ -687,12 +856,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fdcd12c1-7ec3-408f-ba4f-85d9c09bd64e",
+   "id": "572c7674-15e1-48a0-b6cc-86011118bc32",
    "metadata": {},
    "source": [
-    "### Create the requirements file\n",
+    "### Create the dependencies file\n",
     "\n",
-    "Create `requirements.txt` with the Python dependencies for the agent."
+    "The AgentCore CLI reads an agent's dependencies from a `pyproject.toml` in the code directory and resolves them with `uv` for the arm64 runtime when it packages the agent. Create it with the packages the restaurant agent imports."
    ]
   },
   {
@@ -702,27 +871,39 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%writefile requirements.txt\n",
-    "bedrock-agentcore\n",
-    "boto3\n",
-    "strands-agents\n",
-    "strands-agents-tools"
+    "%%writefile restaurant_agent/pyproject.toml\n",
+    "[project]\n",
+    "name = \"strands_restaurant_agent\"\n",
+    "version = \"0.1.0\"\n",
+    "requires-python = \">=3.10\"\n",
+    "dependencies = [\n",
+    "    \"bedrock-agentcore\",\n",
+    "    \"boto3\",\n",
+    "    \"strands-agents\",\n",
+    "    \"strands-agents-tools\",\n",
+    "]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fvbq4yx4qhb",
+   "id": "92c068cb-e714-4a0e-a83a-1a20017b8a36",
    "metadata": {},
    "source": [
     "### Create Execution Role\n",
     "\n",
-    "The restaurant agent requires an IAM execution role with permissions for both Amazon Bedrock AgentCore runtime operations and the agent's business logic. The utility function creates a role that allows the runtime to:\n",
+    "For the Hello Agent, the CLI created the execution role. The restaurant agent needs permissions beyond the standard runtime set, so create the role with boto3 and hand its ARN to the CLI.\n",
     "\n",
-    "- Invoke Amazon Bedrock foundation models\n",
-    "- Pull container images from Amazon ECR\n",
+    "`create_execution_role` in `utils.py` starts from the permissions every agent on AgentCore Runtime needs:\n",
+    "\n",
     "- Write logs to Amazon CloudWatch Logs and send traces to AWS X-Ray\n",
+    "- Publish metrics to Amazon CloudWatch\n",
+    "- Invoke Amazon Bedrock foundation models\n",
+    "- Retrieve workload identity tokens\n",
+    "\n",
+    "The `extra_statements` argument adds what this agent's business logic needs:\n",
+    "\n",
     "- Query Amazon Bedrock Knowledge Bases for restaurant information\n",
-    "- Read and write booking data to Amazon DynamoDB\n",
+    "- Read and write booking data in Amazon DynamoDB\n",
     "- Read configuration from AWS Systems Manager Parameter Store"
    ]
   },
@@ -733,104 +914,153 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from utils import create_execution_role, delete_execution_role\n",
-    "\n",
     "prod_agent_name = \"strands_restaurant_agent\"\n",
-    "EXECUTION_ROLE_ARN, ROLE_NAME = create_execution_role(prod_agent_name)"
+    "\n",
+    "# Permissions for this agent's business logic, on top of the base runtime permissions\n",
+    "restaurant_statements = [\n",
+    "    # Query Amazon Bedrock Knowledge Bases for restaurant and menu information\n",
+    "    {\n",
+    "        \"Effect\": \"Allow\",\n",
+    "        \"Action\": [\"bedrock:Retrieve*\"],\n",
+    "        \"Resource\": f\"arn:aws:bedrock:{region}:{account_id}:knowledge-base/*\",\n",
+    "    },\n",
+    "    # Read and write bookings in Amazon DynamoDB\n",
+    "    {\n",
+    "        \"Effect\": \"Allow\",\n",
+    "        \"Action\": [\"dynamodb:GetItem\", \"dynamodb:PutItem\", \"dynamodb:DeleteItem\", \"dynamodb:Scan\", \"dynamodb:Query\"],\n",
+    "        \"Resource\": f\"arn:aws:dynamodb:{region}:{account_id}:table/*\",\n",
+    "    },\n",
+    "    # Read configuration from AWS Systems Manager Parameter Store\n",
+    "    {\n",
+    "        \"Effect\": \"Allow\",\n",
+    "        \"Action\": [\"ssm:GetParameter*\"],\n",
+    "        \"Resource\": f\"arn:aws:ssm:{region}:{account_id}:parameter/*\",\n",
+    "    },\n",
+    "]\n",
+    "\n",
+    "EXECUTION_ROLE_ARN, ROLE_NAME = create_execution_role(prod_agent_name, extra_statements=restaurant_statements)\n",
+    "print(EXECUTION_ROLE_ARN)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "e3c4882a-3928-40c7-b7ce-26c8241245bd",
+   "id": "0215a2ba-ee73-4476-81e1-b23d8b34ffb7",
    "metadata": {},
    "source": [
-    "### Configure the agent\n",
+    "### Add the agent to the project\n",
     "\n",
-    "Configure the agent using the Starter Toolkit. Unlike the Hello Agent, this agent uses a pre-created execution role (`execution_role`) instead of `auto_create_execution_role=True` to include the additional permissions."
+    "`agentcore add agent --type byo` registers existing code with the project instead of generating a template. It records the code location and entrypoint in `agentcore.json` and leaves your files untouched.\n",
+    "\n",
+    "The CLI has no flag for an existing execution role, so the next cell edits the agent's entry in `agentcore.json` directly to set `executionRoleArn` and pin `runtimeVersion`. It prints the updated entry."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8997b10-e811-4853-9048-05e571e82f8b",
+   "id": "005daa6a-6c10-4c16-9d2d-bd61ced1fcb4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from bedrock_agentcore_starter_toolkit import Runtime\n",
+    "%%bash\n",
+    "cd agentcorelab\n",
+    "agentcore add agent \\\n",
+    "  --name strands_restaurant_agent \\\n",
+    "  --type byo \\\n",
+    "  --language Python \\\n",
+    "  --framework Strands \\\n",
+    "  --model-provider Bedrock \\\n",
+    "  --code-location ../restaurant_agent \\\n",
+    "  --entrypoint app.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6ccf585-7b21-47c8-bd74-b3c2232b0b0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config_path = f\"{PROJECT_NAME}/agentcore/agentcore.json\"\n",
     "\n",
-    "prod_runtime = Runtime()\n",
+    "with open(config_path) as f:\n",
+    "    config = json.load(f)\n",
     "\n",
-    "prod_cfg = prod_runtime.configure(\n",
-    "    entrypoint=\"app.py\",\n",
-    "    execution_role=EXECUTION_ROLE_ARN,  # Use pre-created role with all permissions\n",
-    "    auto_create_ecr=True,\n",
-    "    requirements_file=\"requirements.txt\",\n",
-    "    region=region,\n",
-    "    agent_name=prod_agent_name\n",
-    ")"
+    "agent_config = next(r for r in config[\"runtimes\"] if r[\"name\"] == prod_agent_name)\n",
+    "agent_config[\"executionRoleArn\"] = EXECUTION_ROLE_ARN\n",
+    "agent_config[\"runtimeVersion\"] = PYTHON_RUNTIME\n",
+    "\n",
+    "with open(config_path, \"w\") as f:\n",
+    "    json.dump(config, f, indent=2)\n",
+    "\n",
+    "print(json.dumps(agent_config, indent=2))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6ed59218-6d14-457d-84da-a9c623c117a2",
+   "id": "739a3e34-5015-4976-8629-0c8b6b46ba52",
    "metadata": {},
    "source": [
     "### Deploy to AgentCore Runtime\n",
     "\n",
-    "Launch the agent using the Starter Toolkit's `launch()` method."
+    "Deploy the project again. CloudFormation adds the restaurant agent's runtime to the existing stack. Because the execution role already exists, the stack references it instead of creating one."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ef66a24-2c39-4f8d-9a68-360534827b07",
+   "id": "4a197fe3-6256-4763-aeba-d11a4d7d38e2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "prod_launch = prod_runtime.launch()"
+    "%%bash\n",
+    "cd agentcorelab\n",
+    "agentcore deploy -y"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "sw52q18orio",
+   "id": "35f3f422-eff4-4473-a708-e9445aaa6c45",
    "metadata": {},
    "source": [
     "### Check Deployment Status\n",
     "\n",
-    "Poll the runtime status until the agent reaches a terminal state. The agent is ready to receive requests when the status is `READY`."
+    "Confirm the agent is `READY`, then look up its runtime ARN for the tests that follow."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fbd8b4e-c50a-4877-817b-bb6520802799",
+   "id": "2f25766a-5fd5-4b42-829d-17d824af90af",
    "metadata": {},
    "outputs": [],
    "source": [
-    "prod_status = prod_runtime.status()\n",
-    "status = prod_status.endpoint[\"status\"]\n",
-    "terminal = {\"READY\",\"CREATE_FAILED\",\"DELETE_FAILED\",\"UPDATE_FAILED\"}\n",
-    "while status not in terminal:\n",
-    "    print(\"Production agent status:\", status)\n",
-    "    time.sleep(10)\n",
-    "    prod_status = prod_runtime.status()\n",
-    "    status = prod_status.endpoint[\"status\"]\n",
-    "\n",
-    "print(\"Final production agent status:\", status)"
+    "%%bash\n",
+    "cd agentcorelab\n",
+    "agentcore status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53cf88f3-66e3-4e55-8d5d-d78d97198683",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prod_runtime_arn = get_runtime_arn(PROJECT_NAME, prod_agent_name)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5d1d3f8c-26c0-48fb-a7c9-ae222b1e46a3",
+   "id": "45d96238-d4d4-4609-878f-5a5cb53de81f",
    "metadata": {},
    "source": [
     "## Step 3: Test the Agent\n",
     "\n",
-    "Test the deployed agent by sending requests using the Starter Toolkit's `invoke()` method.\n",
+    "Test the deployed agent by sending requests through the AgentCore data plane with boto3, the same call an application makes.\n",
     "\n",
     "### Create a helper function\n",
     "\n",
-    "Define a helper function to invoke the agent and parse responses."
+    "Define a helper around `invoke_agent_runtime` so the test cells stay short. Reusing a session ID continues a conversation; omitting it starts a new one. The restaurant agent's entrypoint returns plain text, so the parsed body is the response string. The helper returns that text and the session ID."
    ]
   },
   {
@@ -840,34 +1070,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import uuid, json\n",
-    "\n",
-    "def _text_from_toolkit(resp) -> str:\n",
-    "    \"\"\"Return a plain string from Starter Toolkit invoke() responses.\"\"\"\n",
-    "    if isinstance(resp, dict) and \"response\" in resp:\n",
-    "        r = resp[\"response\"]\n",
-    "        return r[0] if isinstance(r, list) and r else str(r)\n",
-    "    # last-resort stringify\n",
-    "    try:\n",
-    "        return json.dumps(resp)\n",
-    "    except Exception:\n",
-    "        return str(resp)\n",
-    "\n",
-    "def invoke_agent(prompt: str, session_id: str | None = None, runtime=None) -> tuple[str, str]:\n",
-    "    \"\"\"\n",
-    "    Invoke your AgentCore runtime using the Starter Toolkit.\n",
-    "    - runtime: defaults to your prod runtime; pass agentcore_runtime_hello to hit the tiny agent.\n",
-    "    Returns (text, session_id).\n",
-    "    \"\"\"\n",
-    "    if runtime is None:\n",
-    "        runtime = prod_runtime  # uses your existing prod Runtime() from the notebook\n",
-    "\n",
-    "    # call the Starter Toolkit wrapper\n",
-    "    resp = runtime.invoke({\"prompt\": prompt}, session_id=session_id)\n",
-    "\n",
-    "    text = _text_from_toolkit(resp)\n",
-    "    sid = resp.get(\"runtimeSessionId\", session_id or str(uuid.uuid4()))\n",
-    "    return text, sid"
+    "def invoke_agent(prompt: str, session_id: str | None = None) -> tuple[str, str]:\n",
+    "    \"\"\"Invoke the restaurant agent on AgentCore Runtime. Returns (text, session_id).\"\"\"\n",
+    "    response = agentcore_client.invoke_agent_runtime(\n",
+    "        agentRuntimeArn=prod_runtime_arn,\n",
+    "        qualifier=\"DEFAULT\",\n",
+    "        runtimeSessionId=session_id or str(uuid.uuid4()),\n",
+    "        payload=json.dumps({\"prompt\": prompt}).encode(),\n",
+    "        contentType=\"application/json\",\n",
+    "        accept=\"application/json\",\n",
+    "    )\n",
+    "    text = json.loads(response[\"response\"].read())\n",
+    "    return text, response[\"runtimeSessionId\"]"
    ]
   },
   {
@@ -891,10 +1105,15 @@
     "print(\"Test 1: Create a booking\")\n",
     "print(\"-\" * 50)\n",
     "\n",
+    "# Book one year out so the date is always in the future\n",
+    "from datetime import date\n",
+    "reservation_date = date.today().replace(year=date.today().year + 1).strftime(\"%B %d, %Y\")\n",
+    "\n",
     "user_query = (\n",
-    "    \"I'd like to make a reservation at Nonna's Hearth for 4 people on December 25th, 2025 at 7:00 PM. My name is John Doe and my email is john@example.com.\"\n",
+    "    f\"I'd like to make a reservation at Nonna's Hearth for 4 people on {reservation_date} at 7:00 PM. \"\n",
+    "    \"My name is John Doe and my email is john@example.com.\"\n",
     ")\n",
-    "response, session_id = invoke_agent(user_query)   # uses prod_runtime by default\n",
+    "response, session_id = invoke_agent(user_query)\n",
     "print(f\"Response: {response}\")\n",
     "print(f\"Session ID: {session_id}\")\n",
     "\n",
@@ -1137,27 +1356,68 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4f4bc28-da31-4246-a3e1-d413a30556af",
+   "id": "c108c74c-25a3-4db7-a289-465f58223a58",
    "metadata": {},
    "source": [
     "## Step 5: Clean up\n",
     "\n",
-    "Delete all resources created during this tutorial."
+    "Delete all resources created during this tutorial. These cells:\n",
+    "\n",
+    "- Read the CloudFormation stack name from the CLI's deployment state file, so it can be checked after deletion\n",
+    "- Run `agentcore remove all`, which empties `agentcore.json`, then `agentcore deploy`, which makes CloudFormation delete the remaining runtime and the stack itself\n",
+    "- Verify with boto3 that neither runtime exists and that the stack is gone, and raise if either check fails\n",
+    "- Delete the execution role created in Step 2\n",
+    "- Remove the local project and agent directories\n",
+    "\n",
+    "The CDK bootstrap stack (`CDKToolkit`) stays. It is shared account infrastructure for any CDK deployment, holds no agent resources, and costs nothing while idle. If this was a throwaway account, delete that stack from the AWS CloudFormation console."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bdcfd70-a54e-4da0-a441-1a95faee81ec",
+   "id": "ae6c5aa2-e41a-4351-9248-69d3768a851c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Starting cleanup process...\")\n",
-    "\n",
-    "!agentcore destroy --agent $prod_agent_name --force --delete-ecr-repo  \n",
-    "!rm -f .bedrock_agentcore.yaml Dockerfile .dockerignore create_booking.py get_booking.py delete_booking.py app.py requirements.txt\n",
-    "\n",
+    "with open(f\"{PROJECT_NAME}/agentcore/.cli/deployed-state.json\") as f:\n",
+    "    STACK_NAME = json.load(f)[\"targets\"][\"default\"][\"resources\"][\"stackName\"]\n",
+    "print(f\"Stack: {STACK_NAME}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b2c0d5a-c286-42bd-99c4-7d151e1c6810",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bash\n",
+    "set -e\n",
+    "cd agentcorelab\n",
+    "agentcore remove all -y\n",
+    "agentcore deploy -y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51c5f589-b199-49fa-b072-de9e26049c29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert_runtimes_absent(PROJECT_NAME, hello_agent_name, prod_agent_name)\n",
+    "assert_stack_absent(STACK_NAME)\n",
     "delete_execution_role(prod_agent_name)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43737a83-f74c-40a9-ae77-8174aa9cfd30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!rm -rf agentcorelab restaurant_agent"
    ]
   },
   {

--- a/python/02-deploy/03-agentcore/utils.py
+++ b/python/02-deploy/03-agentcore/utils.py
@@ -2,8 +2,7 @@
 
 The deploy lifecycle (create project, deploy, remove) runs through the AgentCore CLI directly
 in the notebook, and invocation is shown inline there too. These helpers cover the IAM execution
-role the agent runs with, looking up a runtime ARN, and verifying that resources are gone after
-cleanup.
+role the agent runs with, and verifying that resources are gone after cleanup.
 """
 
 import json
@@ -131,43 +130,6 @@ def delete_execution_role(agent_name):
         print(f"Role already deleted: {role_name}")
 
 
-def _list_runtime_names_to_arns():
-    """Return {agentRuntimeName: agentRuntimeArn} for every runtime in the account and Region."""
-    control = boto3.client("bedrock-agentcore-control")
-    runtimes = {}
-    kwargs = {}
-    while True:
-        page = control.list_agent_runtimes(**kwargs)
-        runtimes.update({r["agentRuntimeName"]: r["agentRuntimeArn"] for r in page["agentRuntimes"]})
-        if "nextToken" not in page:
-            return runtimes
-        kwargs["nextToken"] = page["nextToken"]
-
-
-def get_runtime_arn(project_name, agent_name):
-    """Look up a deployed agent's runtime ARN.
-
-    The AgentCore CLI names each runtime ``<project>_<agent>``. An application typically reads
-    the ARN from configuration; here it is looked up by name so the notebook has no hardcoded ARNs.
-
-    Args:
-        project_name: The CLI project name.
-        agent_name: The agent name as configured in the project.
-
-    Returns:
-        The AgentCore Runtime ARN.
-
-    Raises:
-        RuntimeError: No runtime with that name exists.
-    """
-    runtime_name = f"{project_name}_{agent_name}"
-    arn = _list_runtime_names_to_arns().get(runtime_name)
-    if arn is None:
-        raise RuntimeError(f"No AgentCore Runtime named {runtime_name} found. Has the deploy finished?")
-    print(arn)
-    return arn
-
-
 def assert_runtimes_absent(project_name, *agent_names):
     """Verify that no AgentCore Runtime remains for the given agents.
 
@@ -177,8 +139,12 @@ def assert_runtimes_absent(project_name, *agent_names):
         project_name: The CLI project name.
         *agent_names: Agent names as configured in the project.
     """
+    control = boto3.client("bedrock-agentcore-control")
+    pages = control.get_paginator("list_agent_runtimes").paginate()
+    existing = {r["agentRuntimeName"] for page in pages for r in page["agentRuntimes"]}
+
     expected = {f"{project_name}_{name}" for name in agent_names}
-    survivors = sorted(expected & set(_list_runtime_names_to_arns()))
+    survivors = sorted(expected & existing)
     if survivors:
         raise RuntimeError(f"Runtimes still exist: {survivors}")
     print(f"Verified: no runtime exists for {sorted(expected)}")

--- a/python/02-deploy/03-agentcore/utils.py
+++ b/python/02-deploy/03-agentcore/utils.py
@@ -1,8 +1,8 @@
 """boto3 helpers for the parts of an AgentCore Runtime deployment that an application owns.
 
 The deploy lifecycle (create project, deploy, remove) runs through the AgentCore CLI directly
-in the notebook, and invocation is shown inline there too. These helpers cover the IAM execution
-role the agent runs with, and verifying that resources are gone after cleanup.
+in the notebook, and invocation is shown inline there too. These helpers create and delete the
+IAM execution role that an agent runs with.
 """
 
 import json
@@ -128,40 +128,3 @@ def delete_execution_role(agent_name):
         print(f"Deleted role: {role_name}")
     except iam.exceptions.NoSuchEntityException:
         print(f"Role already deleted: {role_name}")
-
-
-def assert_runtimes_absent(project_name, *agent_names):
-    """Verify that no AgentCore Runtime remains for the given agents.
-
-    Raises if any still exist, so a cleanup that silently did nothing cannot pass.
-
-    Args:
-        project_name: The CLI project name.
-        *agent_names: Agent names as configured in the project.
-    """
-    control = boto3.client("bedrock-agentcore-control")
-    pages = control.get_paginator("list_agent_runtimes").paginate()
-    existing = {r["agentRuntimeName"] for page in pages for r in page["agentRuntimes"]}
-
-    expected = {f"{project_name}_{name}" for name in agent_names}
-    survivors = sorted(expected & existing)
-    if survivors:
-        raise RuntimeError(f"Runtimes still exist: {survivors}")
-    print(f"Verified: no runtime exists for {sorted(expected)}")
-
-
-def assert_stack_absent(stack_name):
-    """Verify that the project's CloudFormation stack has been deleted.
-
-    Args:
-        stack_name: The stack name the AgentCore CLI deployed.
-    """
-    cfn = boto3.client("cloudformation")
-    try:
-        status = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]["StackStatus"]
-    except cfn.exceptions.ClientError as e:
-        if "does not exist" in str(e):
-            print(f"Verified: stack {stack_name} is deleted")
-            return
-        raise
-    raise RuntimeError(f"Stack {stack_name} still exists with status {status}")

--- a/python/02-deploy/03-agentcore/utils.py
+++ b/python/02-deploy/03-agentcore/utils.py
@@ -1,18 +1,31 @@
-"""Utility functions for Amazon Bedrock AgentCore deployment."""
+"""boto3 helpers for the parts of an AgentCore Runtime deployment that an application owns.
 
-import boto3
+The deploy lifecycle (create project, deploy, remove) runs through the AgentCore CLI directly
+in the notebook, and invocation is shown inline there too. These helpers cover the IAM execution
+role the agent runs with, looking up a runtime ARN, and verifying that resources are gone after
+cleanup.
+"""
+
 import json
 import time
 
+import boto3
 
-def create_execution_role(agent_name):
-    """Create an IAM execution role with all permissions required for the restaurant agent.
+
+def create_execution_role(agent_name, extra_statements=None):
+    """Create an IAM execution role that AgentCore Runtime assumes to run the agent.
+
+    The base permissions are the official AgentCore direct code deployment execution role
+    (CloudWatch Logs, X-Ray, CloudWatch metrics, Amazon Bedrock model invocation) plus
+    workload identity access. Pass ``extra_statements`` for whatever the agent's own
+    business logic needs.
 
     Args:
-        agent_name: Name of the agent (used to construct role name)
+        agent_name: Name of the agent (used to construct the role name).
+        extra_statements: Optional list of additional IAM policy statements.
 
     Returns:
-        Tuple of (role_arn, role_name)
+        Tuple of (role_arn, role_name).
     """
     iam = boto3.client("iam")
     sts = boto3.client("sts")
@@ -30,72 +43,57 @@ def create_execution_role(agent_name):
                 "Action": "sts:AssumeRole",
                 "Condition": {
                     "StringEquals": {"aws:SourceAccount": account_id},
-                    "ArnLike": {"aws:SourceArn": f"arn:aws:bedrock-agentcore:{region}:{account_id}:*"}
-                }
+                    "ArnLike": {"aws:SourceArn": f"arn:aws:bedrock-agentcore:{region}:{account_id}:*"},
+                },
             }
-        ]
+        ],
     }
 
-    # Permissions policy for AgentCore runtime execution
-    permissions_policy = {
-        "Version": "2012-10-17",
-        "Statement": [
-            # Allow the runtime to invoke Amazon Bedrock foundation models
-            {
-                "Effect": "Allow",
-                "Action": ["bedrock:InvokeModel*"],
-                "Resource": "*"
-            },
-            # Allow the runtime to pull container images from Amazon ECR
-            {
-                "Effect": "Allow",
-                "Action": ["ecr:BatchGetImage", "ecr:GetDownloadUrlForLayer", "ecr:GetAuthorizationToken"],
-                "Resource": "*"
-            },
-            # Allow the runtime to write logs to Amazon CloudWatch Logs
-            {
-                "Effect": "Allow",
-                "Action": ["logs:*"],
-                "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:*"
-            },
-            # Allow the runtime to send traces to AWS X-Ray
-            {
-                "Effect": "Allow",
-                "Action": ["xray:Put*", "xray:GetSampling*"],
-                "Resource": "*"
-            },
-            # Allow the runtime to publish metrics to Amazon CloudWatch
-            {
-                "Effect": "Allow",
-                "Action": "cloudwatch:PutMetricData",
-                "Resource": "*"
-            },
-            # Allow the runtime to retrieve workload identity tokens
-            {
-                "Effect": "Allow",
-                "Action": ["bedrock-agentcore:GetWorkloadAccessToken*"],
-                "Resource": f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/*"
-            },
-            # Allow the agent to query Amazon Bedrock Knowledge Bases
-            {
-                "Effect": "Allow",
-                "Action": ["bedrock:Retrieve*"],
-                "Resource": f"arn:aws:bedrock:{region}:{account_id}:knowledge-base/*"
-            },
-            # Allow the agent to read and write to Amazon DynamoDB tables
-            {
-                "Effect": "Allow",
-                "Action": ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:DeleteItem", "dynamodb:Scan", "dynamodb:Query"],
-                "Resource": f"arn:aws:dynamodb:{region}:{account_id}:table/*"
-            },
-            # Allow the agent to read parameters from AWS Systems Manager Parameter Store
-            {
-                "Effect": "Allow",
-                "Action": ["ssm:GetParameter*"],
-                "Resource": f"arn:aws:ssm:{region}:{account_id}:parameter/*"
-            }
-        ]
-    }
+    statements = [
+        # Allow the runtime to create its log group and log streams
+        {
+            "Effect": "Allow",
+            "Action": ["logs:DescribeLogStreams", "logs:CreateLogGroup"],
+            "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/*",
+        },
+        {
+            "Effect": "Allow",
+            "Action": ["logs:DescribeLogGroups"],
+            "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:*",
+        },
+        {
+            "Effect": "Allow",
+            "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
+            "Resource": f"arn:aws:logs:{region}:{account_id}:log-group:/aws/bedrock-agentcore/runtimes/*:log-stream:*",
+        },
+        # Allow the runtime to send traces to AWS X-Ray
+        {
+            "Effect": "Allow",
+            "Action": ["xray:PutTraceSegments", "xray:PutTelemetryRecords", "xray:GetSamplingRules", "xray:GetSamplingTargets"],
+            "Resource": "*",
+        },
+        # Allow the runtime to publish metrics to Amazon CloudWatch
+        {
+            "Effect": "Allow",
+            "Action": "cloudwatch:PutMetricData",
+            "Resource": "*",
+            "Condition": {"StringEquals": {"cloudwatch:namespace": "bedrock-agentcore"}},
+        },
+        # Allow the agent to invoke Amazon Bedrock foundation models
+        {
+            "Effect": "Allow",
+            "Action": ["bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream"],
+            "Resource": ["arn:aws:bedrock:*::foundation-model/*", f"arn:aws:bedrock:{region}:{account_id}:*"],
+        },
+        # Allow the runtime to retrieve workload identity tokens
+        {
+            "Effect": "Allow",
+            "Action": ["bedrock-agentcore:GetWorkloadAccessToken*"],
+            "Resource": f"arn:aws:bedrock-agentcore:{region}:{account_id}:workload-identity-directory/*",
+        },
+    ]
+    statements.extend(extra_statements or [])
+    permissions_policy = {"Version": "2012-10-17", "Statement": statements}
 
     # Create the role if it doesn't exist
     try:
@@ -105,31 +103,99 @@ def create_execution_role(agent_name):
         print(f"Role exists: {role_name}")
 
     # Attach the permissions policy to the role
-    iam.put_role_policy(RoleName=role_name, PolicyName="AgentCorePolicy",
-                        PolicyDocument=json.dumps(permissions_policy))
+    iam.put_role_policy(RoleName=role_name, PolicyName="AgentCorePolicy", PolicyDocument=json.dumps(permissions_policy))
 
-    # Wait for IAM role to propagate across AWS regions
+    # Wait for IAM role to propagate
     time.sleep(10)
 
     return f"arn:aws:iam::{account_id}:role/{role_name}", role_name
 
 
 def delete_execution_role(agent_name):
-    """Delete the IAM execution role and its attached policies.
+    """Delete the IAM execution role and its inline policies.
+
+    A role that is already gone is reported, not treated as an error. Any other failure raises.
 
     Args:
-        agent_name: Name of the agent (used to construct role name)
+        agent_name: Name of the agent (used to construct the role name).
     """
     iam = boto3.client("iam")
     role_name = f"agentcore-{agent_name}-role"
 
     try:
-        # Delete all inline policies attached to the role
-        for policy_name in iam.list_role_policies(RoleName=role_name).get("PolicyNames", []):
+        for policy_name in iam.list_role_policies(RoleName=role_name)["PolicyNames"]:
             iam.delete_role_policy(RoleName=role_name, PolicyName=policy_name)
-
-        # Delete the role
         iam.delete_role(RoleName=role_name)
         print(f"Deleted role: {role_name}")
-    except Exception:
-        pass
+    except iam.exceptions.NoSuchEntityException:
+        print(f"Role already deleted: {role_name}")
+
+
+def _list_runtime_names_to_arns():
+    """Return {agentRuntimeName: agentRuntimeArn} for every runtime in the account and Region."""
+    control = boto3.client("bedrock-agentcore-control")
+    runtimes = {}
+    kwargs = {}
+    while True:
+        page = control.list_agent_runtimes(**kwargs)
+        runtimes.update({r["agentRuntimeName"]: r["agentRuntimeArn"] for r in page["agentRuntimes"]})
+        if "nextToken" not in page:
+            return runtimes
+        kwargs["nextToken"] = page["nextToken"]
+
+
+def get_runtime_arn(project_name, agent_name):
+    """Look up a deployed agent's runtime ARN.
+
+    The AgentCore CLI names each runtime ``<project>_<agent>``. An application typically reads
+    the ARN from configuration; here it is looked up by name so the notebook has no hardcoded ARNs.
+
+    Args:
+        project_name: The CLI project name.
+        agent_name: The agent name as configured in the project.
+
+    Returns:
+        The AgentCore Runtime ARN.
+
+    Raises:
+        RuntimeError: No runtime with that name exists.
+    """
+    runtime_name = f"{project_name}_{agent_name}"
+    arn = _list_runtime_names_to_arns().get(runtime_name)
+    if arn is None:
+        raise RuntimeError(f"No AgentCore Runtime named {runtime_name} found. Has the deploy finished?")
+    print(arn)
+    return arn
+
+
+def assert_runtimes_absent(project_name, *agent_names):
+    """Verify that no AgentCore Runtime remains for the given agents.
+
+    Raises if any still exist, so a cleanup that silently did nothing cannot pass.
+
+    Args:
+        project_name: The CLI project name.
+        *agent_names: Agent names as configured in the project.
+    """
+    expected = {f"{project_name}_{name}" for name in agent_names}
+    survivors = sorted(expected & set(_list_runtime_names_to_arns()))
+    if survivors:
+        raise RuntimeError(f"Runtimes still exist: {survivors}")
+    print(f"Verified: no runtime exists for {sorted(expected)}")
+
+
+def assert_stack_absent(stack_name):
+    """Verify that the project's CloudFormation stack has been deleted.
+
+    Args:
+        stack_name: The stack name the AgentCore CLI deployed.
+    """
+    cfn = boto3.client("cloudformation")
+    try:
+        status = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]["StackStatus"]
+    except cfn.exceptions.ClientError as e:
+        if "does not exist" in str(e):
+            print(f"Verified: stack {stack_name} is deleted")
+            return
+        raise
+    raise RuntimeError(f"Stack {stack_name} still exists with status {status}")

--- a/python/02-deploy/README.md
+++ b/python/02-deploy/README.md
@@ -8,7 +8,7 @@ Reference patterns for deploying agents to production environments.
 |--------|----------|-------------|
 | [`01-lambda`](./01-lambda/) | AWS Lambda | Deploy agents as serverless functions |
 | [`02-fargate`](./02-fargate/) | AWS Fargate | Run agents in serverless containers |
-| [`03-agentcore`](./03-agentcore/) | Amazon Bedrock AgentCore | Host agents on purpose-built runtime |
+| [`03-agentcore`](./03-agentcore/) | Amazon Bedrock AgentCore | Host agents on purpose-built runtime with the AgentCore CLI and boto3 |
 | [`04-agentcore-multi-agent`](./04-agentcore-multi-agent/) | Amazon Bedrock AgentCore | Deploy multi-agent A2A orchestration |
 
 [Strands Agents Documentation](https://strandsagents.com/)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- `python/02-deploy/03-agentcore/deploy-agent.ipynb` used the Bedrock AgentCore Starter Toolkit, which is no longer supported. The tutorial now uses the AgentCore CLI for create, deploy, and remove, run as terminal commands in `%%bash` cells, with boto3 for the IAM execution role and `InvokeAgentRuntime`. The Starter Toolkit is gone.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
